### PR TITLE
Fix Statistic Updating Bug

### DIFF
--- a/src/main/java/seedu/momentum/logic/statistic/PeriodicTotalTimeStatistic.java
+++ b/src/main/java/seedu/momentum/logic/statistic/PeriodicTotalTimeStatistic.java
@@ -60,15 +60,14 @@ public class PeriodicTotalTimeStatistic extends Statistic {
         //Only calculate statistics for projects visible to the user
         List<Project> projects = model.getFilteredProjectList();
 
-        ObservableList<StatisticEntry> newTimeList = FXCollections.observableArrayList();
+        timeList.clear();
 
         for (Project project : projects) {
             long totalDuration = calculateTimeSpent(project, weekStart, weekEnd);
 
             StatisticEntry entry = new StatisticEntry(project.getName().fullName, totalDuration);
 
-            newTimeList.add(entry);
-            timeList = newTimeList;
+            timeList.add(entry);
         }
     }
 


### PR DESCRIPTION
Statistics data did not update dynamically when data was changed.

Fixed by reusing the original list provided to the ListView instead of creating a new list everytime the statistic is calculated.

Fixes #50 