### PR TITLE
Add done command

### DIFF
--- a/src/main/java/seedu/momentum/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/momentum/logic/commands/AddCommand.java
@@ -2,6 +2,7 @@ package seedu.momentum.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.momentum.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.momentum.logic.parser.CliSyntax.PREFIX_COMPLETION_STATUS;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_DEADLINE_DATE;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_DEADLINE_TIME;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
@@ -26,6 +27,7 @@ public class AddCommand extends Command {
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + "[" + PREFIX_DESCRIPTION + "DESCRIPTION] "
+            + "[" + PREFIX_COMPLETION_STATUS + "] "
             + String.format("[%sDEADLINE_DATE [%sDEADLINE_TIME] ] ", PREFIX_DEADLINE_DATE, PREFIX_DEADLINE_TIME)
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "

--- a/src/main/java/seedu/momentum/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/momentum/logic/commands/EditCommand.java
@@ -1,6 +1,7 @@
 package seedu.momentum.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.momentum.logic.parser.CliSyntax.PREFIX_COMPLETION_STATUS;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_DEADLINE_DATE;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_DEADLINE_TIME;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
@@ -21,6 +22,7 @@ import seedu.momentum.commons.util.CollectionUtil;
 import seedu.momentum.logic.commands.exceptions.CommandException;
 import seedu.momentum.model.Model;
 import seedu.momentum.model.ViewMode;
+import seedu.momentum.model.project.CompletionStatus;
 import seedu.momentum.model.project.Deadline;
 import seedu.momentum.model.project.Description;
 import seedu.momentum.model.project.Name;
@@ -44,6 +46,7 @@ public class EditCommand extends Command {
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_DESCRIPTION + "DESCRIPTION] "
+            + "[" + PREFIX_COMPLETION_STATUS + "] "
             + String.format("[%sDEADLINE_DATE [%sDEADLINE_TIME] ] ", PREFIX_DEADLINE_DATE, PREFIX_DEADLINE_TIME)
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 ";
@@ -59,7 +62,7 @@ public class EditCommand extends Command {
     /**
      * Create a EditCommand that edits a project.
      *
-     * @param index of the project in the filtered project list to edit.
+     * @param index                     of the project in the filtered project list to edit.
      * @param editTrackedItemDescriptor details to edit the project with.
      */
     public EditCommand(Index index, EditTrackedItemDescriptor editTrackedItemDescriptor) {
@@ -74,9 +77,9 @@ public class EditCommand extends Command {
     /**
      * Create a EditCommand that edits a task.
      *
-     * @param index of the project in the filtered project list to edit.
+     * @param index                     of the project in the filtered project list to edit.
      * @param editTrackedItemDescriptor details to edit the project with.
-     * @param parentProject The parent project of the task to edit.
+     * @param parentProject             The parent project of the task to edit.
      */
     public EditCommand(Index index, EditTrackedItemDescriptor editTrackedItemDescriptor, Project parentProject) {
         requireNonNull(index);
@@ -125,6 +128,10 @@ public class EditCommand extends Command {
         Name updatedName = editTrackedItemDescriptor.getName().orElse(trackedItemToEdit.getName());
         Description updatedDescription =
                 editTrackedItemDescriptor.getDescription().orElse(trackedItemToEdit.getDescription());
+        CompletionStatus updatedCompletionStatus = trackedItemToEdit.getCompletionStatus();
+        if (editTrackedItemDescriptor.getCompletionStatus().isPresent()) {
+            updatedCompletionStatus = updatedCompletionStatus.reverse();
+        }
         Date createdDate = trackedItemToEdit.getCreatedDate();
         Deadline updatedDeadline = editTrackedItemDescriptor.getDeadline().orElse(trackedItemToEdit.getDeadline());
         if (editTrackedItemDescriptor.getDeadline().isPresent()
@@ -142,11 +149,11 @@ public class EditCommand extends Command {
             UniqueTrackedItemList taskList = new UniqueTrackedItemList();
             taskList.setTrackedItems(projectToEdit.getTaskList());
 
-            return new Project(updatedName, updatedDescription, createdDate, updatedDeadline, updatedTags,
-                    durationList, trackedItemToEdit.getTimer(), taskList);
+            return new Project(updatedName, updatedDescription, updatedCompletionStatus, createdDate, updatedDeadline,
+                    updatedTags, durationList, trackedItemToEdit.getTimer(), taskList);
         } else {
-            return new Task(updatedName, updatedDescription, createdDate, updatedDeadline, updatedTags,
-                    durationList, trackedItemToEdit.getTimer());
+            return new Task(updatedName, updatedDescription, updatedCompletionStatus, createdDate, updatedDeadline,
+                    updatedTags, durationList, trackedItemToEdit.getTimer());
         }
     }
 
@@ -175,6 +182,7 @@ public class EditCommand extends Command {
     public static class EditTrackedItemDescriptor {
         private Name name;
         private Description description;
+        private CompletionStatus completionStatus;
         private Deadline deadline;
         private Set<Tag> tags;
 
@@ -188,6 +196,7 @@ public class EditCommand extends Command {
         public EditTrackedItemDescriptor(EditTrackedItemDescriptor toCopy) {
             setName(toCopy.name);
             setDescription(toCopy.description);
+            setCompletionStatus(toCopy.completionStatus);
             setDeadline(toCopy.deadline);
             setTags(toCopy.tags);
         }
@@ -196,7 +205,7 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, description, deadline, tags);
+            return CollectionUtil.isAnyNonNull(name, description, completionStatus, deadline, tags);
         }
 
         public void setName(Name name) {
@@ -213,6 +222,14 @@ public class EditCommand extends Command {
 
         public Optional<Description> getDescription() {
             return Optional.ofNullable(description);
+        }
+
+        public void setCompletionStatus(CompletionStatus completionStatus) {
+            this.completionStatus = completionStatus;
+        }
+
+        public Optional<CompletionStatus> getCompletionStatus() {
+            return Optional.ofNullable(completionStatus);
         }
 
         public void setDeadline(Deadline deadline) {
@@ -257,6 +274,7 @@ public class EditCommand extends Command {
 
             return getName().equals(e.getName())
                     && getDescription().equals(e.getDescription())
+                    && getCompletionStatus().equals(e.getCompletionStatus())
                     && getDeadline().equals(e.getDeadline())
                     && getTags().equals(e.getTags());
         }

--- a/src/main/java/seedu/momentum/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/momentum/logic/commands/FindCommand.java
@@ -2,6 +2,7 @@ package seedu.momentum.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.momentum.logic.parser.CliSyntax.FIND_TYPE;
+import static seedu.momentum.logic.parser.CliSyntax.PREFIX_COMPLETION_STATUS;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_TAG;
@@ -26,6 +27,7 @@ public class FindCommand extends Command {
             + "[" + FIND_TYPE + "FIND_TYPE ] "
             + "[" + PREFIX_NAME + "NAME_KEYWORD [MORE_NAME_KEYWORDS]... ] "
             + "[" + PREFIX_DESCRIPTION + "DESCRIPTION_KEYWORD [MORE_DESCRIPTION_KEYWORDS]... ] "
+            + "[" + PREFIX_COMPLETION_STATUS + "] "
             + "[" + PREFIX_TAG + "TAG_KEYWORD [MORE_TAG_KEYWORDS]... ] \n"
             + "Example: " + COMMAND_WORD + " " + FIND_TYPE + "all " + PREFIX_NAME + "alice bob charlie "
             + PREFIX_DESCRIPTION + "likes dim sum " + PREFIX_TAG + "friends";

--- a/src/main/java/seedu/momentum/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/momentum/logic/commands/SortCommand.java
@@ -1,6 +1,7 @@
 package seedu.momentum.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.momentum.logic.parser.CliSyntax.PREFIX_COMPLETION_STATUS;
 import static seedu.momentum.logic.parser.CliSyntax.SORT_ORDER;
 import static seedu.momentum.logic.parser.CliSyntax.SORT_TYPE;
 
@@ -25,14 +26,12 @@ public class SortCommand extends Command {
     public static final String OUTPUT_ASCENDING_ORDER = "ascending";
     public static final String OUTPUT_DESCENDING_ORDER = "descending";
 
-
-
-
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts projects by specified type and order.\n"
             + "Default sort is of type: Alphabetical and order: Ascending. \n"
             + "Parameters: "
             + "[" + SORT_TYPE + "SORT_TYPE ] "
             + "[" + SORT_ORDER + "SORT_ORDER ] "
+            + "[" + PREFIX_COMPLETION_STATUS + "] "
             + "Example: " + COMMAND_WORD + " " + SORT_TYPE + "alpha " + SORT_ORDER + "asc";
 
     public static final String MESSAGE_INVALID_SORT_TYPE_OR_ORDER = "Sort type can only be one of the following: \n"
@@ -44,20 +43,23 @@ public class SortCommand extends Command {
     public static final String MESSAGE_SORT_SUCCESS = "List has been sorted in %1$s%2$s order";
 
     private SortType sortType;
-    private boolean isAscending;
-    private boolean isDefault;
+    private final boolean isAscending;
+    private final boolean isDefault;
+    private final boolean isSortedByCompletionStatus;
 
     /**
      * Creates a SortCommand to sort the list of projects.
      *
-     * @param sortType Type of sort applied to projects.
-     * @param isAscending Boolean value to check if order of sort applied to projects is ascending.
-     * @param isDefault Boolean value to check if SortCommand is default.
+     * @param sortType                   Type of sort applied to projects.
+     * @param isAscending                Boolean value to check if order of sort applied to projects is ascending.
+     * @param isDefault                  Boolean value to check if SortCommand is default.
+     * @param isSortedByCompletionStatus Boolean value to check if SortCommand is sorted by completion status.
      */
-    public SortCommand(SortType sortType, boolean isAscending, boolean isDefault) {
+    public SortCommand(SortType sortType, boolean isAscending, boolean isDefault, boolean isSortedByCompletionStatus) {
         this.sortType = sortType;
         this.isAscending = isAscending;
         this.isDefault = isDefault;
+        this.isSortedByCompletionStatus = isSortedByCompletionStatus;
     }
 
     @Override
@@ -65,11 +67,8 @@ public class SortCommand extends Command {
         requireNonNull(model);
 
         String type = "";
-        String order = isDefault
-                ? OUTPUT_DEFAULT_TYPE
-                : isAscending
-                ? OUTPUT_ASCENDING_ORDER
-                : OUTPUT_DESCENDING_ORDER;
+        String order = isDefault ? OUTPUT_DEFAULT_TYPE : isAscending
+                ? OUTPUT_ASCENDING_ORDER : OUTPUT_DESCENDING_ORDER;
 
         switch (sortType) {
         case ALPHA:
@@ -89,7 +88,7 @@ public class SortCommand extends Command {
             sortType = SortType.ALPHA;
         }
 
-        model.orderFilteredProjectList(sortType, isAscending);
+        model.orderFilteredProjectList(sortType, isAscending, isSortedByCompletionStatus);
         return new CommandResult(String.format(MESSAGE_SORT_SUCCESS, type, order));
     }
 
@@ -97,9 +96,10 @@ public class SortCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof SortCommand // instanceof handles nulls
-                && sortType.equals(((SortCommand) other).sortType)) // field check
-                && isAscending == (((SortCommand) other).isAscending) // field check
-                && isDefault == (((SortCommand) other).isDefault); //field check
+                && sortType.equals(((SortCommand) other).sortType) // field check
+                && isAscending == ((SortCommand) other).isAscending // field check
+                && isDefault == ((SortCommand) other).isDefault // field check
+                && isSortedByCompletionStatus == ((SortCommand) other).isSortedByCompletionStatus); // field check
     }
 
 }

--- a/src/main/java/seedu/momentum/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/momentum/logic/parser/AddCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.momentum.logic.parser;
 
 import static seedu.momentum.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.momentum.logic.parser.CliSyntax.PREFIX_COMPLETION_STATUS;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_DEADLINE_DATE;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_DEADLINE_TIME;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
@@ -16,6 +17,7 @@ import seedu.momentum.logic.commands.AddCommand;
 import seedu.momentum.logic.parser.exceptions.ParseException;
 import seedu.momentum.model.Model;
 import seedu.momentum.model.ViewMode;
+import seedu.momentum.model.project.CompletionStatus;
 import seedu.momentum.model.project.Deadline;
 import seedu.momentum.model.project.Description;
 import seedu.momentum.model.project.Name;
@@ -37,8 +39,8 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args, Model model) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DESCRIPTION, PREFIX_DEADLINE_DATE,
-                        PREFIX_DEADLINE_TIME, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DESCRIPTION, PREFIX_COMPLETION_STATUS,
+                        PREFIX_DEADLINE_DATE, PREFIX_DEADLINE_TIME, PREFIX_TAG);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME)
                 || !argMultimap.getPreamble().isEmpty()) {
@@ -46,13 +48,18 @@ public class AddCommandParser implements Parser<AddCommand> {
         }
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        Description description;
 
+        Description description;
         if (!argMultimap.getValue(PREFIX_DESCRIPTION).isPresent()) {
             description = Description.EMPTY_DESCRIPTION;
         } else {
             description = ParserUtil.parseDescription(
                     argMultimap.getValue(PREFIX_DESCRIPTION).get());
+        }
+
+        CompletionStatus completionStatus = new CompletionStatus();
+        if (argMultimap.getValue(PREFIX_COMPLETION_STATUS).isPresent()) {
+            completionStatus = completionStatus.reverse();
         }
 
         Date createdDate = new Date(Clock.now().getDate());
@@ -65,10 +72,10 @@ public class AddCommandParser implements Parser<AddCommand> {
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         if (model.getViewMode() == ViewMode.PROJECTS) {
-            return new AddCommand(new Project(name, description, createdDate, deadline, tagList));
+            return new AddCommand(new Project(name, description, completionStatus, createdDate, deadline, tagList));
         } else {
-            return new AddCommand(new Task(name, description, createdDate, deadline, tagList),
-                model.getCurrentProject());
+            return new AddCommand(new Task(name, description, completionStatus, createdDate, deadline, tagList),
+                    model.getCurrentProject());
         }
     }
 

--- a/src/main/java/seedu/momentum/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/momentum/logic/parser/CliSyntax.java
@@ -8,6 +8,7 @@ public class CliSyntax {
     // Prefix definitions
     public static final Prefix PREFIX_NAME = new Prefix("n/");
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");
+    public static final Prefix PREFIX_COMPLETION_STATUS = new Prefix("c/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_DEADLINE_DATE = new Prefix("dd/");
     public static final Prefix PREFIX_DEADLINE_TIME = new Prefix("dt/");

--- a/src/main/java/seedu/momentum/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/momentum/logic/parser/EditCommandParser.java
@@ -2,6 +2,7 @@ package seedu.momentum.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.momentum.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.momentum.logic.parser.CliSyntax.PREFIX_COMPLETION_STATUS;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_DEADLINE_DATE;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_DEADLINE_TIME;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
@@ -19,6 +20,7 @@ import seedu.momentum.logic.commands.EditCommand;
 import seedu.momentum.logic.parser.exceptions.ParseException;
 import seedu.momentum.model.Model;
 import seedu.momentum.model.ViewMode;
+import seedu.momentum.model.project.CompletionStatus;
 import seedu.momentum.model.tag.Tag;
 
 /**
@@ -33,9 +35,8 @@ public class EditCommandParser implements Parser<EditCommand> {
      */
     public EditCommand parse(String args, Model model) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DESCRIPTION, PREFIX_DEADLINE_DATE,
-                        PREFIX_DEADLINE_TIME, PREFIX_TAG);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DESCRIPTION,
+                PREFIX_COMPLETION_STATUS, PREFIX_DEADLINE_DATE, PREFIX_DEADLINE_TIME, PREFIX_TAG);
 
         Index index;
 
@@ -46,13 +47,18 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         EditCommand.EditTrackedItemDescriptor editTrackedItemDescriptor = new EditCommand.EditTrackedItemDescriptor();
+
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             editTrackedItemDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }
 
         if (argMultimap.getValue(PREFIX_DESCRIPTION).isPresent()) {
             editTrackedItemDescriptor.setDescription(
-                ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get()));
+                    ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get()));
+        }
+
+        if (argMultimap.getValue(PREFIX_COMPLETION_STATUS).isPresent()) {
+            editTrackedItemDescriptor.setCompletionStatus(new CompletionStatus());
         }
 
         // use a default date to parse the deadline first

--- a/src/main/java/seedu/momentum/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/momentum/logic/parser/FindCommandParser.java
@@ -2,6 +2,7 @@ package seedu.momentum.logic.parser;
 
 import static seedu.momentum.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.momentum.logic.parser.CliSyntax.FIND_TYPE;
+import static seedu.momentum.logic.parser.CliSyntax.PREFIX_COMPLETION_STATUS;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_TAG;
@@ -17,6 +18,7 @@ import seedu.momentum.logic.commands.FindCommand;
 import seedu.momentum.logic.parser.exceptions.ParseException;
 import seedu.momentum.model.Model;
 import seedu.momentum.model.project.TrackedItem;
+import seedu.momentum.model.project.predicates.CompletionStatusPredicate;
 import seedu.momentum.model.project.predicates.DescriptionContainsKeywordsPredicate;
 import seedu.momentum.model.project.predicates.FindType;
 import seedu.momentum.model.project.predicates.NameContainsKeywordsPredicate;
@@ -37,9 +39,10 @@ public class FindCommandParser implements Parser<FindCommand> {
      */
     public FindCommand parse(String args, Model model) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DESCRIPTION, PREFIX_TAG, FIND_TYPE);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DESCRIPTION, PREFIX_COMPLETION_STATUS,
+                        PREFIX_TAG, FIND_TYPE);
 
-        Prefix[] prefixesToParse = new Prefix[] {PREFIX_NAME, PREFIX_DESCRIPTION, PREFIX_TAG};
+        Prefix[] prefixesToParse = new Prefix[] {PREFIX_NAME, PREFIX_DESCRIPTION, PREFIX_COMPLETION_STATUS, PREFIX_TAG};
 
         if (!argMultimap.getPreamble().isEmpty() || !anyPrefixPresent(argMultimap, prefixesToParse)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
@@ -93,6 +96,12 @@ public class FindCommandParser implements Parser<FindCommand> {
             predicateList.add(new NameContainsKeywordsPredicate(findType, keywords));
         } else if (prefix.equals(PREFIX_DESCRIPTION)) {
             predicateList.add(new DescriptionContainsKeywordsPredicate(findType, keywords));
+        } else if (prefix.equals(PREFIX_COMPLETION_STATUS)) {
+            if (keywords.size() != 1) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+            }
+            predicateList.add(new CompletionStatusPredicate(findType, keywords));
         } else if (prefix.equals(PREFIX_TAG)) {
             predicateList.add(new TagListContainsKeywordsPredicate(findType, keywords));
         }

--- a/src/main/java/seedu/momentum/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/momentum/logic/parser/SortCommandParser.java
@@ -7,6 +7,7 @@ import static seedu.momentum.logic.commands.SortCommand.INPUT_ASCENDING_ORDER;
 import static seedu.momentum.logic.commands.SortCommand.INPUT_CREATED_TYPE;
 import static seedu.momentum.logic.commands.SortCommand.INPUT_DEADLINE_TYPE;
 import static seedu.momentum.logic.commands.SortCommand.INPUT_DESCENDING_ORDER;
+import static seedu.momentum.logic.parser.CliSyntax.PREFIX_COMPLETION_STATUS;
 import static seedu.momentum.logic.parser.CliSyntax.SORT_ORDER;
 import static seedu.momentum.logic.parser.CliSyntax.SORT_TYPE;
 
@@ -26,7 +27,7 @@ public class SortCommandParser implements Parser<SortCommand> {
     public SortCommand parse(String args, Model model) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, SORT_TYPE, SORT_ORDER);
+                ArgumentTokenizer.tokenize(args, SORT_TYPE, SORT_ORDER, PREFIX_COMPLETION_STATUS);
 
         if (!argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
@@ -42,7 +43,12 @@ public class SortCommandParser implements Parser<SortCommand> {
             sortType = SortType.NULL;
         }
 
-        return new SortCommand(sortType, isAscending, isDefault);
+        boolean isSortedByCompletionStatus = true;
+        if (argMultimap.getValue(PREFIX_COMPLETION_STATUS).isPresent()) {
+            isSortedByCompletionStatus = false;
+        }
+
+        return new SortCommand(sortType, isAscending, isDefault, isSortedByCompletionStatus);
     }
 
     private String parseSortOrder(ArgumentMultimap argMultimap) throws ParseException {

--- a/src/main/java/seedu/momentum/model/Model.java
+++ b/src/main/java/seedu/momentum/model/Model.java
@@ -114,7 +114,7 @@ public interface Model {
      *
      * @throws NullPointerException if {@code sortType} is null.
      */
-    void orderFilteredProjectList(SortType sortType, boolean isAscending);
+    void orderFilteredProjectList(SortType sortType, boolean isAscending, boolean isSortedByCompletionStatus);
 
     void viewProjects();
 

--- a/src/main/java/seedu/momentum/model/ModelManager.java
+++ b/src/main/java/seedu/momentum/model/ModelManager.java
@@ -30,7 +30,8 @@ public class ModelManager implements Model {
     private final ObservableList<TrackedItem> runningTimers;
     private Predicate<TrackedItem> currentPredicate;
     private SortType currentSortType;
-    private boolean currentSortIsAscending;
+    private boolean isCurrentSortAscending;
+    private boolean isCurrentSortIsByCompletionStatus;
     private ViewMode viewMode;
     private Project currentProject;
     private ObservableList<TrackedItem> viewList;
@@ -49,7 +50,8 @@ public class ModelManager implements Model {
 
         currentPredicate = PREDICATE_SHOW_ALL_TRACKED_ITEMS;
         currentSortType = SortType.ALPHA;
-        currentSortIsAscending = true;
+        isCurrentSortAscending = true;
+        isCurrentSortIsByCompletionStatus = true;
         viewMode = ViewMode.PROJECTS;
 
         this.viewList = FXCollections.observableArrayList();
@@ -140,7 +142,7 @@ public class ModelManager implements Model {
     @Override
     public void addTrackedItem(TrackedItem trackedItem) {
         projectBook.addTrackedItem(trackedItem);
-        orderFilteredProjectList(currentSortType, currentSortIsAscending);
+        orderFilteredProjectList(currentSortType, isCurrentSortAscending, isCurrentSortIsByCompletionStatus);
         updateFilteredProjectList(PREDICATE_SHOW_ALL_TRACKED_ITEMS);
     }
 
@@ -171,11 +173,12 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void orderFilteredProjectList(SortType orderType, boolean isAscending) {
-        requireAllNonNull(orderType, isAscending);
-        currentSortIsAscending = isAscending;
+    public void orderFilteredProjectList(SortType orderType, boolean isAscending, boolean isSortedByCompletionStatus) {
+        requireAllNonNull(orderType, isAscending, isSortedByCompletionStatus);
+        isCurrentSortAscending = isAscending;
+        isCurrentSortIsByCompletionStatus = isSortedByCompletionStatus;
         currentSortType = orderType;
-        projectBook.setOrder(orderType, isAscending);
+        projectBook.setOrder(orderType, isAscending, isSortedByCompletionStatus);
         updateFilteredProjectList(currentPredicate);
     }
 

--- a/src/main/java/seedu/momentum/model/ProjectBook.java
+++ b/src/main/java/seedu/momentum/model/ProjectBook.java
@@ -67,10 +67,11 @@ public class ProjectBook implements ReadOnlyProjectBook {
      *
      * @param sortType type of sort.
      * @param isAscending order of sort.
+     * @param isSortedByCompletionStatus sorted by completion status.
      */
-    public void setOrder(SortType sortType, boolean isAscending) {
+    public void setOrder(SortType sortType, boolean isAscending, boolean isSortedByCompletionStatus) {
         requireNonNull(sortType);
-        trackedItems.setOrder(sortType, isAscending);
+        trackedItems.setOrder(sortType, isAscending, isSortedByCompletionStatus);
     }
 
     //// project-level operations

--- a/src/main/java/seedu/momentum/model/project/CompletionStatus.java
+++ b/src/main/java/seedu/momentum/model/project/CompletionStatus.java
@@ -1,0 +1,71 @@
+package seedu.momentum.model.project;
+
+/**
+ * Represents a Project's Completion status in the project book
+ * Guarantees: immutable.
+ */
+public class CompletionStatus implements Comparable<CompletionStatus> {
+    public static final CompletionStatus COMPLETED = new CompletionStatus(true);
+
+    // toString fields
+    private static final String COMPLETED_ICON = "\u2714";
+    private static final String INCOMPLETE_ICON = "\u2718";
+
+    private final boolean completionStatus;
+
+    /**
+     * Constructs a {@code CompletionStatus}.
+     */
+    public CompletionStatus() {
+        this.completionStatus = false;
+    }
+
+    private CompletionStatus(boolean newCompletionStatus) {
+        this.completionStatus = newCompletionStatus;
+    }
+
+    /**
+     * Returns true if the project is completed, false otherwise.
+     *
+     * @return isCompleted
+     */
+    public boolean isCompleted() {
+        return this.completionStatus;
+    }
+
+    /**
+     * Returns the reversed completion status.
+     * If the completion status was true, return a completion status with false..
+     *
+     * @return the reverse completion status
+     */
+    public CompletionStatus reverse() {
+        return new CompletionStatus(!this.completionStatus);
+    }
+
+    @Override
+    public String toString() {
+        return this.completionStatus ? COMPLETED_ICON : INCOMPLETE_ICON;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof CompletionStatus // instanceof handles nulls
+                && this.completionStatus == ((CompletionStatus) other).completionStatus); // state check
+    }
+
+    @Override
+    public int compareTo(CompletionStatus other) {
+        return this.completionStatus == other.completionStatus
+                ? 0
+                : completionStatus
+                ? 1 : -1;
+    }
+
+    @Override
+    public int hashCode() {
+        return Boolean.hashCode(this.completionStatus);
+    }
+
+}

--- a/src/main/java/seedu/momentum/model/project/CompletionStatus.java
+++ b/src/main/java/seedu/momentum/model/project/CompletionStatus.java
@@ -57,10 +57,7 @@ public class CompletionStatus implements Comparable<CompletionStatus> {
 
     @Override
     public int compareTo(CompletionStatus other) {
-        return this.completionStatus == other.completionStatus
-                ? 0
-                : completionStatus
-                ? 1 : -1;
+        return Boolean.compare(this.completionStatus, other.completionStatus);
     }
 
     @Override

--- a/src/main/java/seedu/momentum/model/project/Project.java
+++ b/src/main/java/seedu/momentum/model/project/Project.java
@@ -23,49 +23,54 @@ public class Project extends TrackedItem {
     /**
      * Constructs a {@code Project}.
      *
-     * @param name A valid name.
-     * @param description A description of the project.
-     * @param createdDate A date associated with the creation of the project.
-     * @param deadline A deadline associated with the project.
-     * @param tags A set of tags associated to the project.
-     * @param durations A list of {@code WorkDuration} associated with the project.
-     * @param timer A timer associated with the project.
-     * @param taskList UniqueTrackedListList associated with the project.
+     * @param name             A valid name.
+     * @param description      A description of the project.
+     * @param completionStatus A completion status of the project.
+     * @param createdDate      A date associated with the creation of the project.
+     * @param deadline         A deadline associated with the project.
+     * @param tags             A set of tags associated to the project.
+     * @param durations        A list of {@code WorkDuration} associated with the project.
+     * @param timer            A timer associated with the project.
+     * @param taskList         UniqueTrackedListList associated with the project.
      */
-    public Project(Name name, Description description, Date createdDate, Deadline deadline,
-                   Set<Tag> tags, UniqueDurationList durations, Timer timer, UniqueTrackedItemList taskList) {
-        super(name, description, createdDate, deadline, tags, durations, timer);
+    public Project(Name name, Description description, CompletionStatus completionStatus, Date createdDate,
+                   Deadline deadline, Set<Tag> tags, UniqueDurationList durations, Timer timer,
+                   UniqueTrackedItemList taskList) {
+        super(name, description, completionStatus, createdDate, deadline, tags, durations, timer);
         this.taskList = taskList;
     }
 
     /**
      * Constructs a {@code Project}.
      *
-     * @param name A valid name.
-     * @param description A description of the project.
-     * @param createdDate A date associated with the creation of the project.
-     * @param deadline A deadline associated with the project.
-     * @param tags A set of tags associated to the project.
-     * @param durations A list of {@code WorkDuration} associated with the project.
-     * @param timer A timer associated with the project.
+     * @param name             A valid name.
+     * @param description      A description of the project.
+     * @param completionStatus A completion status of the project.
+     * @param createdDate      A date associated with the creation of the project.
+     * @param deadline         A deadline associated with the project.
+     * @param tags             A set of tags associated to the project.
+     * @param durations        A list of {@code WorkDuration} associated with the project.
+     * @param timer            A timer associated with the project.
      */
-    public Project(Name name, Description description, Date createdDate, Deadline deadline,
-                   Set<Tag> tags, UniqueDurationList durations, Timer timer) {
-        super(name, description, createdDate, deadline, tags, durations, timer);
+    public Project(Name name, Description description, CompletionStatus completionStatus, Date createdDate,
+                   Deadline deadline, Set<Tag> tags, UniqueDurationList durations, Timer timer) {
+        super(name, description, completionStatus, createdDate, deadline, tags, durations, timer);
         taskList = new UniqueTrackedItemList();
     }
 
     /**
      * Constructs a new {@code Project}
      *
-     * @param name A valid name.
-     * @param createdDate A date associated with the creation of the project
-     * @param deadline A deadline associated with the project.
-     * @param description A description of the project.
-     * @param tags A set of tags associated to the project.
+     * @param name             A valid name.
+     * @param completionStatus A completion status of the project.
+     * @param createdDate      A date associated with the creation of the project
+     * @param deadline         A deadline associated with the project.
+     * @param description      A description of the project.
+     * @param tags             A set of tags associated to the project.
      */
-    public Project(Name name, Description description, Date createdDate, Deadline deadline, Set<Tag> tags) {
-        super(name, description, createdDate, deadline, tags);
+    public Project(Name name, Description description, CompletionStatus completionStatus, Date createdDate,
+                   Deadline deadline, Set<Tag> tags) {
+        super(name, description, completionStatus, createdDate, deadline, tags);
         taskList = new UniqueTrackedItemList();
     }
 
@@ -77,7 +82,8 @@ public class Project extends TrackedItem {
     @Override
     public Project startTimer() {
         Timer newTimer = timer.start();
-        return new Project(name, description, createdDate, deadline, tags, durations, newTimer, taskList);
+        return new Project(name, description, completionStatus, createdDate, deadline, tags, durations, newTimer,
+                taskList);
     }
 
     /**
@@ -93,7 +99,8 @@ public class Project extends TrackedItem {
         UniqueDurationList newDurations = new UniqueDurationList();
         newDurations.setDurations(durations);
         newDurations.add(duration);
-        return new Project(name, description, createdDate, deadline, tags, newDurations, newTimer, taskList);
+        return new Project(name, description, completionStatus, createdDate, deadline, tags, newDurations, newTimer,
+                taskList);
     }
 
     /**
@@ -129,7 +136,7 @@ public class Project extends TrackedItem {
     /**
      * Edits a task is in the {@code Project}'s {@code UniqueTrackedItemList}.
      *
-     * @param target task to be replaced.
+     * @param target     task to be replaced.
      * @param editedTask task to replace the original task with.
      */
     public void setTask(TrackedItem target, TrackedItem editedTask) {

--- a/src/main/java/seedu/momentum/model/project/Task.java
+++ b/src/main/java/seedu/momentum/model/project/Task.java
@@ -19,28 +19,31 @@ public class Task extends TrackedItem {
      *
      * @param name A valid name.
      * @param description A description of the task.
+     * @param completionStatus A completion status of the task.
      * @param createdDate A date associated with the creation of the task.
      * @param deadline A deadline associated with the task.
      * @param tags A set of tags associated to the task.
      * @param durations A list of {@code WorkDuration} associated with the task.
      * @param timer A timer associated with the task.
      */
-    public Task(Name name, Description description, Date createdDate, Deadline deadline,
-                   Set<Tag> tags, UniqueDurationList durations, Timer timer) {
-        super(name, description, createdDate, deadline, tags, durations, timer);
+    public Task(Name name, Description description, CompletionStatus completionStatus, Date createdDate,
+                Deadline deadline, Set<Tag> tags, UniqueDurationList durations, Timer timer) {
+        super(name, description, completionStatus, createdDate, deadline, tags, durations, timer);
     }
 
     /**
      * Constructs a new {@code Task}
      *
      * @param name A valid name.
-     * @param createdDate A date associated with the creation of the task
+     * @param completionStatus A completion status of the task.
+     * @param createdDate A date associated with the creation of the task.
      * @param deadline A deadline associated with the task.
      * @param description A description of the task.
      * @param tags A set of tags associated to the task.
      */
-    public Task(Name name, Description description, Date createdDate, Deadline deadline, Set<Tag> tags) {
-        super(name, description, createdDate, deadline, tags);
+    public Task(Name name, Description description, CompletionStatus completionStatus, Date createdDate,
+                Deadline deadline, Set<Tag> tags) {
+        super(name, description, completionStatus, createdDate, deadline, tags);
     }
 
     /**
@@ -51,7 +54,7 @@ public class Task extends TrackedItem {
     @Override
     public Task startTimer() {
         Timer newTimer = timer.start();
-        return new Task(name, description, createdDate, deadline, tags, durations, newTimer);
+        return new Task(name, description, completionStatus, createdDate, deadline, tags, durations, newTimer);
     }
 
     /**
@@ -67,7 +70,7 @@ public class Task extends TrackedItem {
         UniqueDurationList newDurations = new UniqueDurationList();
         newDurations.setDurations(durations);
         newDurations.add(duration);
-        return new Task(name, description, createdDate, deadline, tags, newDurations, newTimer);
+        return new Task(name, description, completionStatus, createdDate, deadline, tags, newDurations, newTimer);
     }
 
     /**

--- a/src/main/java/seedu/momentum/model/project/TrackedItem.java
+++ b/src/main/java/seedu/momentum/model/project/TrackedItem.java
@@ -26,6 +26,7 @@ public abstract class TrackedItem {
 
     // data fields
     protected final Description description;
+    protected final CompletionStatus completionStatus;
     protected final Date createdDate;
     protected final Deadline deadline;
     protected final Set<Tag> tags = new HashSet<>();
@@ -35,19 +36,21 @@ public abstract class TrackedItem {
     /**
      * Constructs a {@code TrackedItem}.
      *
-     * @param name A valid name.
-     * @param description A description of the tracked item.
-     * @param createdDate A date associated with the creation of the tracked item.
-     * @param deadline A deadline associated with the tracked item.
-     * @param tags A set of tags associated to the tracked item.
-     * @param durations A list of {@code WorkDuration} associated with the tracked item.
-     * @param timer A timer associated with the tracked item.
+     * @param name             A valid name.
+     * @param description      A description of the tracked item.
+     * @param completionStatus A completion status of the tracked item.
+     * @param createdDate      A date associated with the creation of the tracked item.
+     * @param deadline         A deadline associated with the tracked item.
+     * @param tags             A set of tags associated to the tracked item.
+     * @param durations        A list of {@code WorkDuration} associated with the tracked item.
+     * @param timer            A timer associated with the tracked item.
      */
-    public TrackedItem(Name name, Description description, Date createdDate, Deadline deadline, Set<Tag> tags,
-                   UniqueDurationList durations, Timer timer) {
+    public TrackedItem(Name name, Description description, CompletionStatus completionStatus, Date createdDate,
+                       Deadline deadline, Set<Tag> tags, UniqueDurationList durations, Timer timer) {
         requireAllNonNull(name, tags);
         this.name = name;
         this.description = description;
+        this.completionStatus = completionStatus;
         this.createdDate = createdDate;
         this.deadline = deadline;
         this.tags.addAll(tags);
@@ -58,16 +61,19 @@ public abstract class TrackedItem {
     /**
      * Constructs a new {@code TrackedItem}
      *
-     * @param name A valid name.
-     * @param createdDate A date associated with the creation of the tracked item
-     * @param deadline A deadline associated with the tracked item.
-     * @param description A description of the tracked item.
-     * @param tags A set of tags associated to the tracked item.
+     * @param name             A valid name.
+     * @param completionStatus A completion status of the tracked item.
+     * @param createdDate      A date associated with the creation of the tracked item
+     * @param deadline         A deadline associated with the tracked item.
+     * @param description      A description of the tracked item.
+     * @param tags             A set of tags associated to the tracked item.
      */
-    public TrackedItem(Name name, Description description, Date createdDate, Deadline deadline, Set<Tag> tags) {
+    public TrackedItem(Name name, Description description, CompletionStatus completionStatus, Date createdDate,
+                       Deadline deadline, Set<Tag> tags) {
         requireAllNonNull(name, tags);
         this.name = name;
         this.description = description;
+        this.completionStatus = completionStatus;
         this.createdDate = createdDate;
         this.deadline = deadline;
         this.tags.addAll(tags);
@@ -81,6 +87,10 @@ public abstract class TrackedItem {
 
     public Description getDescription() {
         return description;
+    }
+
+    public CompletionStatus getCompletionStatus() {
+        return completionStatus;
     }
 
     public Date getCreatedDate() {
@@ -161,6 +171,7 @@ public abstract class TrackedItem {
         return otherTrackedItem != null
                 && otherTrackedItem.getName().equals(getName())
                 && otherTrackedItem.getDescription().equals(getDescription())
+                && otherTrackedItem.getCompletionStatus().equals(getCompletionStatus())
                 && otherTrackedItem.getCreatedDate().equals(getCreatedDate())
                 && otherTrackedItem.getDeadline().equals(getDeadline());
     }
@@ -186,17 +197,18 @@ public abstract class TrackedItem {
 
         TrackedItem otherTrackedItem = (TrackedItem) other;
         return otherTrackedItem.getName().equals(getName())
-                && otherTrackedItem.getTags().equals(getTags())
-                && otherTrackedItem.getDurationList().equals(getDurationList())
                 && otherTrackedItem.getDescription().equals(getDescription())
+                && otherTrackedItem.getCompletionStatus().equals(getCompletionStatus())
                 && otherTrackedItem.getCreatedDate().equals(getCreatedDate())
-                && otherTrackedItem.getDeadline().equals(getDeadline());
+                && otherTrackedItem.getDeadline().equals(getDeadline())
+                && otherTrackedItem.getTags().equals(getTags())
+                && otherTrackedItem.getDurationList().equals(getDurationList());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, description, createdDate, deadline, tags, durations, timer);
+        return Objects.hash(name, description, completionStatus, createdDate, deadline, tags, durations, timer);
     }
 
     @Override
@@ -205,6 +217,8 @@ public abstract class TrackedItem {
         builder.append(getName())
                 .append(" Description: ")
                 .append(getDescription())
+                .append("Completion Status:")
+                .append(getCompletionStatus())
                 .append(" Created Date: ")
                 .append(getCreatedDate())
                 .append(" Deadline: ")

--- a/src/main/java/seedu/momentum/model/project/UniqueTrackedItemList.java
+++ b/src/main/java/seedu/momentum/model/project/UniqueTrackedItemList.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.momentum.model.project.comparators.CompletionStatusCompare;
 import seedu.momentum.model.project.comparators.CreatedDateCompare;
 import seedu.momentum.model.project.comparators.DeadlineCompare;
 import seedu.momentum.model.project.comparators.NameCompare;
@@ -23,7 +24,7 @@ import seedu.momentum.model.project.exceptions.TrackableItemNotFoundException;
  * the tracked item being added or updated is unique in terms of identity in the UniqueTrackedItemList. However, the
  * removal of a tracked item uses TrackedItem#equals(Object) so as to ensure that the tracked item with exactly the
  * same fields will be removed.
- *
+ * <p>
  * Supports a minimal set of list operations.
  *
  * @see TrackedItem#isSameTrackedItem(TrackedItem)
@@ -109,25 +110,25 @@ public class UniqueTrackedItemList implements Iterable<TrackedItem> {
     /**
      * Sets the order of the list of tracked items according to given {@code sortType} and {@code isAscending}.
      *
-     * @param sortType type of sort.
-     * @param isAscending order of sort.
+     * @param sortType                   type of sort.
+     * @param isAscending                order of sort.
+     * @param isSortedByCompletionStatus sort by creation status.
      */
-    public void setOrder(SortType sortType, boolean isAscending) {
-
+    public void setOrder(SortType sortType, boolean isAscending, boolean isSortedByCompletionStatus) {
         requireNonNull(sortType);
 
         switch (sortType) {
         case ALPHA:
-            setOrderAlphaType(isAscending);
+            setOrderAlphaType(isAscending, isSortedByCompletionStatus);
             break;
         case DEADLINE:
-            setOrderDeadlineType(isAscending);
+            setOrderDeadlineType(isAscending, isSortedByCompletionStatus);
             break;
         case CREATED:
-            setOrderCreatedDateType(isAscending);
+            setOrderCreatedDateType(isAscending, isSortedByCompletionStatus);
             break;
         case NULL:
-            setOrderNullType(isAscending);
+            setOrderNullType(isAscending, isSortedByCompletionStatus);
             break;
         default:
             // Will always be one of the above. Default does nothing.
@@ -138,57 +139,84 @@ public class UniqueTrackedItemList implements Iterable<TrackedItem> {
     /**
      * Sets the order of list of tracked items by alphabetical order, ascending or descending based on user input.
      *
-     * @param isAscending order of sort specified by user.
+     * @param isAscending                order of sort specified by user.
+     * @param isSortedByCompletionStatus sort by creation status.
      */
-    private void setOrderAlphaType(boolean isAscending) {
+    private void setOrderAlphaType(boolean isAscending, boolean isSortedByCompletionStatus) {
         Comparator<TrackedItem> nameCompare = new NameCompare();
         nameCompare = isAscending ? nameCompare : nameCompare.reversed();
         sortType = SortType.ALPHA;
-        internalList.sort(nameCompare);
+
+        Comparator<TrackedItem> compare;
+        if (isSortedByCompletionStatus) {
+            compare = new CompletionStatusCompare().thenComparing(nameCompare);
+        } else {
+            compare = nameCompare;
+        }
+        internalList.sort(compare);
     }
 
     /**
      * Sets the order of list of tracked items by deadline order, ascending or descending based on user input.
      *
-     * @param isAscending order of sort specified by user.
+     * @param isAscending                order of sort specified by user.
+     * @param isSortedByCompletionStatus sort by creation status.
      */
-    private void setOrderDeadlineType(boolean isAscending) {
+    private void setOrderDeadlineType(boolean isAscending, boolean isSortedByCompletionStatus) {
         Comparator<TrackedItem> nameCompare = new NameCompare();
-        Comparator<HashMap<String, Object>> deadlineCompare = new DeadlineCompare();
-        deadlineCompare = isAscending ? deadlineCompare : deadlineCompare.reversed();
+        Comparator<HashMap<String, Object>> deadlineCompareHashMap = new DeadlineCompare();
+        deadlineCompareHashMap = isAscending ? deadlineCompareHashMap : deadlineCompareHashMap.reversed();
+        Comparator<TrackedItem> deadlineCompare = Comparator.comparing(TrackedItem::getNullOrDeadline,
+                Comparator.nullsLast(deadlineCompareHashMap));
+        deadlineCompare = deadlineCompare.thenComparing(nameCompare);
         sortType = SortType.DEADLINE;
-        internalList.sort(Comparator.comparing(TrackedItem::getNullOrDeadline, Comparator.nullsLast(deadlineCompare))
-                .thenComparing(nameCompare));
+
+        Comparator<TrackedItem> compare;
+        if (isSortedByCompletionStatus) {
+            compare = new CompletionStatusCompare().thenComparing(deadlineCompare);
+        } else {
+            compare = deadlineCompare;
+        }
+        internalList.sort(compare);
     }
 
     /**
      * Sets the order of list of tracked items by created date order, ascending or descending based on user input.
      *
-     * @param isAscending order of sort specified by user.
+     * @param isAscending                order of sort specified by user.
+     * @param isSortedByCompletionStatus sort by creation status.
      */
-    private void setOrderCreatedDateType(boolean isAscending) {
+    private void setOrderCreatedDateType(boolean isAscending, boolean isSortedByCompletionStatus) {
         Comparator<TrackedItem> createdDateCompare = new CreatedDateCompare();
         createdDateCompare = isAscending ? createdDateCompare : createdDateCompare.reversed();
         this.sortType = SortType.CREATED;
-        internalList.sort(createdDateCompare);
+
+        Comparator<TrackedItem> compare;
+        if (isSortedByCompletionStatus) {
+            compare = new CompletionStatusCompare().thenComparing(createdDateCompare);
+        } else {
+            compare = createdDateCompare;
+        }
+        internalList.sort(compare);
     }
 
     /**
      * Sets the order of the list of tracked items to current sort type with specified order
      * if sort type has not been specified by user.
      *
-     * @param isAscending order of sort specified by user.
+     * @param isAscending                order of sort specified by user.
+     * @param isSortedByCompletionStatus sort by creation status.
      */
-    private void setOrderNullType(boolean isAscending) {
-        switch(this.sortType) {
+    private void setOrderNullType(boolean isAscending, boolean isSortedByCompletionStatus) {
+        switch (this.sortType) {
         case ALPHA:
-            setOrder(SortType.ALPHA, isAscending);
+            setOrder(SortType.ALPHA, isAscending, isSortedByCompletionStatus);
             break;
         case DEADLINE:
-            setOrder(SortType.DEADLINE, isAscending);
+            setOrder(SortType.DEADLINE, isAscending, isSortedByCompletionStatus);
             break;
         case CREATED:
-            setOrder(SortType.CREATED, isAscending);
+            setOrder(SortType.CREATED, isAscending, isSortedByCompletionStatus);
             break;
         default:
             // Will always be one of the above. Default does nothing.
@@ -212,7 +240,7 @@ public class UniqueTrackedItemList implements Iterable<TrackedItem> {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof UniqueTrackedItemList // instanceof handles nulls
-                        && internalList.equals(((UniqueTrackedItemList) other).internalList));
+                && internalList.equals(((UniqueTrackedItemList) other).internalList));
     }
 
     @Override

--- a/src/main/java/seedu/momentum/model/project/comparators/CompletionStatusCompare.java
+++ b/src/main/java/seedu/momentum/model/project/comparators/CompletionStatusCompare.java
@@ -9,6 +9,7 @@ import seedu.momentum.model.project.TrackedItem;
  * Represents a comparator that compares the completion status of a project.
  */
 public class CompletionStatusCompare implements Comparator<TrackedItem> {
+
     /**
      * Compares completion status of two tracked items.
      *

--- a/src/main/java/seedu/momentum/model/project/comparators/CompletionStatusCompare.java
+++ b/src/main/java/seedu/momentum/model/project/comparators/CompletionStatusCompare.java
@@ -1,0 +1,25 @@
+package seedu.momentum.model.project.comparators;
+
+import java.util.Comparator;
+
+import seedu.momentum.model.project.CompletionStatus;
+import seedu.momentum.model.project.TrackedItem;
+
+/**
+ * Represents a comparator that compares the completion status of a project.
+ */
+public class CompletionStatusCompare implements Comparator<TrackedItem> {
+    /**
+     * Compares completion status of two tracked items.
+     *
+     * @param t1 first tracked item to compare.
+     * @param t2 second tracked item to compare.
+     * @return integer values for comparison.
+     */
+    public int compare(TrackedItem t1, TrackedItem t2) {
+        CompletionStatus status1 = t1.getCompletionStatus();
+        CompletionStatus status2 = t2.getCompletionStatus();
+        return status1.compareTo(status2);
+    }
+
+}

--- a/src/main/java/seedu/momentum/model/project/predicates/CompletionStatusPredicate.java
+++ b/src/main/java/seedu/momentum/model/project/predicates/CompletionStatusPredicate.java
@@ -1,0 +1,51 @@
+package seedu.momentum.model.project.predicates;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.momentum.model.project.TrackedItem;
+
+/**
+ * Tests that a {@code TrackedItem}'s {@code CompletionStatus} is incomplete.
+ */
+public class CompletionStatusPredicate implements Predicate<TrackedItem> {
+    public static final String COMPLETED_KEYWORD = "completed";
+    public static final String INCOMPLETE_KEYWORD = "incomplete";
+
+    private final List<String> keywords;
+    private final FindType findType;
+
+    /**
+     * Predicate to check whether the {@code CompletionStatus} of a {@code Project} is incomplete.
+     *
+     * @param findType enum to indicate whether the find type to be used for this find command.
+     * @param keywords list of keywords to check for matches.
+     */
+    public CompletionStatusPredicate(FindType findType, List<String> keywords) {
+        assert keywords.size() == 1;
+        this.findType = findType;
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(TrackedItem trackedItem) {
+        String keyword = keywords.get(0);
+        boolean status = trackedItem.getCompletionStatus().isCompleted();
+        switch (keyword) {
+        case COMPLETED_KEYWORD:
+            return status;
+        case INCOMPLETE_KEYWORD:
+            return !status;
+        default:
+            return false;
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof CompletionStatusPredicate // instanceof handles nulls
+                && keywords.equals(((CompletionStatusPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/momentum/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/momentum/model/util/SampleDataUtil.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import seedu.momentum.commons.core.Date;
 import seedu.momentum.model.ProjectBook;
 import seedu.momentum.model.ReadOnlyProjectBook;
+import seedu.momentum.model.project.CompletionStatus;
 import seedu.momentum.model.project.Deadline;
 import seedu.momentum.model.project.Description;
 import seedu.momentum.model.project.Name;
@@ -23,31 +24,37 @@ public class SampleDataUtil {
         return new Project[]{
             new Project(new Name("Alex Yeoh"),
                     new Description("description"),
+                    new CompletionStatus(),
                     new Date("2019-10-04"),
                     new Deadline("2020-10-04", new Date("2019-10-04")),
                     getTagSet("friends")),
             new Project(new Name("Bernice Yu"),
                     new Description("description"),
+                    new CompletionStatus().reverse(),
                     new Date("2019-10-10"),
                     new Deadline("2020-10-10", "01:01:21", new Date("2019-10-10")),
                     getTagSet("colleagues", "friends")),
             new Project(new Name("Charlotte Oliveiro"),
                     new Description("description"),
+                    new CompletionStatus(),
                     new Date("2019-06-22"),
                     new Deadline(),
                     getTagSet("neighbours")),
             new Project(new Name("David Li"),
                     new Description("description"),
+                    new CompletionStatus().reverse(),
                     new Date("2019-11-04"),
                     new Deadline("2020-11-04", "08:10:21", new Date("2019-11-04")),
                     getTagSet("family")),
             new Project(new Name("Irfan Ibrahim"),
                     Description.EMPTY_DESCRIPTION,
+                    new CompletionStatus().reverse(),
                     new Date("2019-10-24"),
                     new Deadline("2020-10-24", new Date("2019-10-24")),
                     getTagSet("classmates")),
             new Project(new Name("Roy Balakrishnan"),
                     Description.EMPTY_DESCRIPTION,
+                    new CompletionStatus(),
                     new Date("2019-01-04"),
                     new Deadline(),
                     getTagSet("colleagues"))

--- a/src/main/java/seedu/momentum/storage/JsonAdaptedProject.java
+++ b/src/main/java/seedu/momentum/storage/JsonAdaptedProject.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.momentum.commons.core.Date;
 import seedu.momentum.commons.exceptions.IllegalValueException;
+import seedu.momentum.model.project.CompletionStatus;
 import seedu.momentum.model.project.Deadline;
 import seedu.momentum.model.project.Description;
 import seedu.momentum.model.project.Name;
@@ -31,6 +32,7 @@ class JsonAdaptedProject {
 
     private final String name;
     private final String description;
+    private final boolean completionStatus;
     private final String createdDate;
     private final JsonAdaptedDeadline deadline;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
@@ -44,6 +46,7 @@ class JsonAdaptedProject {
     @JsonCreator
     public JsonAdaptedProject(@JsonProperty("name") String name,
                               @JsonProperty("description") String description,
+                              @JsonProperty("completionStatus") boolean completionStatus,
                               @JsonProperty("createdDate") String createdDate,
                               @JsonProperty("deadline") JsonAdaptedDeadline deadline,
                               @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
@@ -52,6 +55,7 @@ class JsonAdaptedProject {
                               @JsonProperty("taskList") List<JsonAdaptedTask> taskList) {
         this.name = name;
         this.description = description;
+        this.completionStatus = completionStatus;
         this.createdDate = createdDate;
         this.deadline = deadline;
         if (tagged != null) {
@@ -68,6 +72,7 @@ class JsonAdaptedProject {
 
     public JsonAdaptedProject(String name,
                               String description,
+                              boolean completionStatus,
                               String createdDate,
                               JsonAdaptedDeadline deadline,
                               List<JsonAdaptedTag> tagged,
@@ -75,6 +80,7 @@ class JsonAdaptedProject {
                               JsonAdaptedTimer timer) {
         this.name = name;
         this.description = description;
+        this.completionStatus = completionStatus;
         this.createdDate = createdDate;
         this.deadline = deadline;
         if (tagged != null) {
@@ -92,6 +98,7 @@ class JsonAdaptedProject {
     public JsonAdaptedProject(Project source) {
         name = source.getName().fullName;
         description = source.getDescription().value;
+        completionStatus = source.getCompletionStatus().isCompleted();
         createdDate = source.getCreatedDate().toString();
         deadline = new JsonAdaptedDeadline(source.getDeadline());
         tagged.addAll(source.getTags().stream()
@@ -127,6 +134,13 @@ class JsonAdaptedProject {
 
         final Description modelDescription = new Description(description);
 
+        final CompletionStatus modelCompletionStatus;
+        if (completionStatus) {
+            modelCompletionStatus = new CompletionStatus().reverse();
+        } else {
+            modelCompletionStatus = new CompletionStatus();
+        }
+
         if (!Date.isValid(createdDate)) {
             throw new IllegalValueException(Date.MESSAGE_CONSTRAINTS);
         }
@@ -153,8 +167,8 @@ class JsonAdaptedProject {
         UniqueTrackedItemList modelTasks = new UniqueTrackedItemList();
         modelTasks.setTrackedItems(projectTasks);
 
-        return new Project(modelName, modelDescription, modelCreatedDate, modelDeadline, modelTags, modelDurations,
-                modelTimer, modelTasks);
+        return new Project(modelName, modelDescription, modelCompletionStatus, modelCreatedDate, modelDeadline,
+                modelTags, modelDurations, modelTimer, modelTasks);
     }
 
 }

--- a/src/main/java/seedu/momentum/storage/JsonAdaptedTask.java
+++ b/src/main/java/seedu/momentum/storage/JsonAdaptedTask.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.momentum.commons.core.Date;
 import seedu.momentum.commons.exceptions.IllegalValueException;
+import seedu.momentum.model.project.CompletionStatus;
 import seedu.momentum.model.project.Deadline;
 import seedu.momentum.model.project.Description;
 import seedu.momentum.model.project.Name;
@@ -30,6 +31,7 @@ class JsonAdaptedTask {
 
     private final String name;
     private final String description;
+    private final boolean completionStatus;
     private final String createdDate;
     private final JsonAdaptedDeadline deadline;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
@@ -41,14 +43,16 @@ class JsonAdaptedTask {
      */
     @JsonCreator
     public JsonAdaptedTask(@JsonProperty("name") String name,
-                                  @JsonProperty("description") String description,
-                                  @JsonProperty("createdDate") String createdDate,
-                                  @JsonProperty("deadline") JsonAdaptedDeadline deadline,
-                                  @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
-                                  @JsonProperty("durations") List<JsonAdaptedWorkDuration> durations,
-                                  @JsonProperty("timer") JsonAdaptedTimer timer) {
+                           @JsonProperty("description") String description,
+                           @JsonProperty("completionStatus") boolean completionStatus,
+                           @JsonProperty("createdDate") String createdDate,
+                           @JsonProperty("deadline") JsonAdaptedDeadline deadline,
+                           @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
+                           @JsonProperty("durations") List<JsonAdaptedWorkDuration> durations,
+                           @JsonProperty("timer") JsonAdaptedTimer timer) {
         this.name = name;
         this.description = description;
+        this.completionStatus = completionStatus;
         this.createdDate = createdDate;
         this.deadline = deadline;
         if (tagged != null) {
@@ -66,6 +70,7 @@ class JsonAdaptedTask {
     public JsonAdaptedTask(TrackedItem source) {
         name = source.getName().fullName;
         description = source.getDescription().value;
+        completionStatus = source.getCompletionStatus().isCompleted();
         createdDate = source.getCreatedDate().toString();
         deadline = new JsonAdaptedDeadline(source.getDeadline());
         tagged.addAll(source.getTags().stream()
@@ -98,6 +103,13 @@ class JsonAdaptedTask {
 
         final Description modelDescription = new Description(description);
 
+        final CompletionStatus modelCompletionStatus;
+        if (completionStatus) {
+            modelCompletionStatus = new CompletionStatus().reverse();
+        } else {
+            modelCompletionStatus = new CompletionStatus();
+        }
+
         if (!Date.isValid(createdDate)) {
             throw new IllegalValueException(Date.MESSAGE_CONSTRAINTS);
         }
@@ -117,8 +129,8 @@ class JsonAdaptedTask {
 
         final Timer modelTimer = timer == null ? new Timer() : timer.toModelType();
 
-        return new Task(modelName, modelDescription, modelCreatedDate, modelDeadline, modelTags, modelDurations,
-                modelTimer);
+        return new Task(modelName, modelDescription, modelCompletionStatus, modelCreatedDate, modelDeadline,
+                modelTags, modelDurations, modelTimer);
     }
 
 }

--- a/src/main/java/seedu/momentum/ui/TrackedItemCard.java
+++ b/src/main/java/seedu/momentum/ui/TrackedItemCard.java
@@ -17,6 +17,11 @@ public class TrackedItemCard extends UiPart<Region> {
 
     private static final String FXML = "TrackedItemListCard.fxml";
 
+    private static final String STYLE_TEXT = "-fx-text-fill: ";
+    private static final String STYLE_COLOUR_RED = "-fx-red";
+    private static final String STYLE_COLOUR_GREEN = "-fx-green";
+    private static final String STYLE_COLOUR_YELLOW = "-fx-yellow";
+
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
      * As a consequence, UI elements' variable names cannot be set to such keywords
@@ -31,6 +36,8 @@ public class TrackedItemCard extends UiPart<Region> {
     private HBox cardPane;
     @FXML
     private Label name;
+    @FXML
+    private Label completionStatus;
     @FXML
     private Text id;
     @FXML
@@ -51,6 +58,9 @@ public class TrackedItemCard extends UiPart<Region> {
         id.setText(displayedIndex + ". ");
         name.setText(trackedItem.getName().fullName);
 
+        completionStatus.setText(trackedItem.getCompletionStatus().toString());
+        setCompletionStatusStyle(completionStatus);
+
         if (!trackedItem.getDescription().isEmpty()) {
             Label descLabel = new Label(trackedItem.getDescription().value);
             descLabel.setWrapText(true);
@@ -64,23 +74,35 @@ public class TrackedItemCard extends UiPart<Region> {
         deadline.getChildren().add(deadlineLabel);
 
         trackedItem.getTags().stream()
-            .sorted(Comparator.comparing(tag -> tag.tagName))
-            .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+                .sorted(Comparator.comparing(tag -> tag.tagName))
+                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+    }
+
+    private void setCompletionStatusStyle(Label completionStatus) {
+        String style = STYLE_TEXT;
+
+        if (trackedItem.getCompletionStatus().isCompleted()) {
+            style += STYLE_COLOUR_GREEN;
+        } else {
+            style += STYLE_COLOUR_RED;
+        }
+
+        completionStatus.setStyle(style);
     }
 
     private void setDeadlineStyle(Label deadline) {
-        String style = "-fx-text-fill: ";
+        String style = STYLE_TEXT;
 
         if (trackedItem.getDeadline().isEmpty()) {
             style += "-fx-cool-gray-0";
         } else {
             long daysToDeadline = trackedItem.getDeadline().daysToDeadline();
             if (daysToDeadline > 7) {
-                style += "-fx-green";
+                style += STYLE_COLOUR_GREEN;
             } else if (daysToDeadline < 4) {
-                style += "-fx-red";
+                style += STYLE_COLOUR_RED;
             } else {
-                style += "-fx-yellow";
+                style += STYLE_COLOUR_YELLOW;
             }
         }
 

--- a/src/main/resources/view/Momentum.css
+++ b/src/main/resources/view/Momentum.css
@@ -155,7 +155,7 @@
     -fx-padding: 0 8 8 0;
 }
 
-.project-list #id, #name {
+.project-list #id, #name, #completionStatus {
     -fx-font-size: 20;
 }
 
@@ -163,7 +163,7 @@
     -fx-fill: -fx-white;
 }
 
-.project-list #name, #description {
+.project-list #name, #description, #completionStatus {
     -fx-padding: 0 8 0 0;
 }
 

--- a/src/main/resources/view/TrackedItemListCard.fxml
+++ b/src/main/resources/view/TrackedItemListCard.fxml
@@ -33,6 +33,7 @@
                            </HBox.margin>
                         </Text>
                         <Label fx:id="name" text="\$name" wrapText="true" />
+                        <Label fx:id="completionStatus" text="\$completionStatus" wrapText="true"/>
                      </children>
                   </HBox>
                   <FlowPane fx:id="tags">

--- a/src/test/data/JsonSerializableProjectBookTest/duplicateProjectProjectBook.json
+++ b/src/test/data/JsonSerializableProjectBookTest/duplicateProjectProjectBook.json
@@ -2,11 +2,13 @@
   "projects": [ {
     "name": "Alice Pauline",
     "description": "Likes coding",
+    "completionStatus": false,
     "createdDate": "2000-11-05",
     "tagged": [ "friends" ]
   }, {
     "name": "Alice Pauline",
     "description": "Likes coding",
+    "completionStatus": false,
     "createdDate": "2000-11-05"
   } ]
 }

--- a/src/test/data/JsonSerializableProjectBookTest/typicalProjectsProjectBook.json
+++ b/src/test/data/JsonSerializableProjectBookTest/typicalProjectsProjectBook.json
@@ -4,6 +4,7 @@
     "name" : "Alice Pauline",
     "description": "Likes coding",
     "createdDate": "2000-11-05",
+    "completionStatus": false,
     "deadline": {
       "date": "2020-11-05",
       "time": "11:11:11"
@@ -13,6 +14,7 @@
     "name" : "Benson Meier",
     "description": "Likes dogs",
     "createdDate": "2000-11-05",
+    "completionStatus": true,
     "deadline": {
       "date": "2020-11-05",
       "time": "12:43:12"
@@ -30,16 +32,19 @@
   }, {
     "name" : "Carl Kurz",
     "description": "Likes poodles",
+    "completionStatus": true,
     "createdDate": "2019-08-02",
     "tagged" : [ ]
   }, {
     "name" : "Daniel Meier",
     "description": "Likes cats",
+    "completionStatus": false,
     "createdDate": "2019-05-21",
     "tagged" : [ "friends" ]
   }, {
     "name" : "Elle Meyer",
     "description": "Likes elephants",
+    "completionStatus": false,
     "createdDate": "2019-07-21",
     "deadline": {
       "date": "2020-07-21",
@@ -49,6 +54,7 @@
   }, {
     "name" : "Fiona Kunz",
     "description": "Likes starbucks",
+    "completionStatus": false,
     "createdDate": "2019-03-21",
     "deadline": {
       "date": "2020-03-21",
@@ -58,6 +64,7 @@
   }, {
     "name" : "George Best",
     "description": "Likes you",
+    "completionStatus": true,
     "createdDate": "2019-07-28",
     "tagged" : [ ]
   } ]

--- a/src/test/java/seedu/momentum/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/momentum/logic/commands/AddCommandIntegrationTest.java
@@ -48,7 +48,7 @@ public class AddCommandIntegrationTest {
 
         // alphabetical order -> Dana gets placed in between Carl and Daniel
         Model expectedModel = new ModelManager(model.getProjectBook(), new UserPrefs());
-        expectedModel.orderFilteredProjectList(SortType.ALPHA, true);
+        expectedModel.orderFilteredProjectList(SortType.ALPHA, true, true);
         expectedModel.addTrackedItem(dana);
 
         assertCommandSuccess(addDanaCommand, model,

--- a/src/test/java/seedu/momentum/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/momentum/logic/commands/AddCommandTest.java
@@ -142,7 +142,8 @@ public class AddCommandTest {
         }
 
         @Override
-        public void orderFilteredProjectList(SortType sortType, boolean isAscending) {
+        public void orderFilteredProjectList(SortType sortType, boolean isAscending,
+                                             boolean isSortedByCompletionStatus) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/momentum/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/momentum/logic/commands/CommandTestUtil.java
@@ -2,6 +2,7 @@ package seedu.momentum.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.momentum.logic.parser.CliSyntax.PREFIX_COMPLETION_STATUS;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_DEADLINE_DATE;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_DEADLINE_TIME;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
@@ -20,6 +21,7 @@ import seedu.momentum.logic.commands.exceptions.CommandException;
 import seedu.momentum.logic.parser.exceptions.ParseException;
 import seedu.momentum.model.Model;
 import seedu.momentum.model.ProjectBook;
+import seedu.momentum.model.project.CompletionStatus;
 import seedu.momentum.model.project.TrackedItem;
 import seedu.momentum.model.project.predicates.FindType;
 import seedu.momentum.model.project.predicates.NameContainsKeywordsPredicate;
@@ -34,6 +36,8 @@ public class CommandTestUtil {
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_DESCRIPTION_AMY = "Loves coffee";
     public static final String VALID_DESCRIPTION_BOB = "Hates coffee";
+    public static final CompletionStatus VALID_COMPLETION_STATUS_AMY = new CompletionStatus();
+    public static final CompletionStatus VALID_COMPLETION_STATUS_BOB = new CompletionStatus().reverse();
     public static final String VALID_CREATED_DATE_AMY = "2019-12-02";
     public static final String VALID_CREATED_DATE_BOB = "2019-10-02";
     public static final String VALID_DEADLINE_DATE_AMY = "2030-12-02";
@@ -46,6 +50,7 @@ public class CommandTestUtil {
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
     public static final String DESCRIPTION_DESC_AMY = " " + PREFIX_DESCRIPTION + VALID_DESCRIPTION_AMY;
     public static final String DESCRIPTION_DESC_BOB = " " + PREFIX_DESCRIPTION + VALID_DESCRIPTION_BOB;
+    public static final String COMPLETION_STATUS_DESC_BOB = " " + PREFIX_COMPLETION_STATUS;
     public static final String DEADLINE_DATE_DESC_AMY = " " + PREFIX_DEADLINE_DATE + VALID_DEADLINE_DATE_AMY;
     public static final String DEADLINE_DATE_DESC_BOB = " " + PREFIX_DEADLINE_DATE + VALID_DEADLINE_DATE_BOB;
     public static final String DEADLINE_TIME_DESC_AMY = " " + PREFIX_DEADLINE_TIME + VALID_DEADLINE_TIME_AMY;
@@ -63,7 +68,8 @@ public class CommandTestUtil {
     public static final String VALID_DESCENDING_SORT_ORDER = " " + SORT_ORDER + "dsc";
     public static final String VALID_ALPHA_SORT_TYPE = " " + SORT_TYPE + "alpha";
     public static final String VALID_DEADLINE_SORT_TYPE = " " + SORT_TYPE + "deadline";
-    public static final String VALID_CREATED_DATE_SORT_TYPE = " " + SORT_TYPE + "created";
+    public static final String VALID_CREATED_DATE_SORT_TYPE = " " + SORT_TYPE + "created"
+            + " " + PREFIX_COMPLETION_STATUS;
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
@@ -79,6 +85,7 @@ public class CommandTestUtil {
                 .build();
         DESC_BOB = new EditTrackedItemDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withDescription(VALID_DESCRIPTION_BOB)
+                .withCompletionStatus(VALID_COMPLETION_STATUS_BOB)
                 .withDeadline(VALID_DEADLINE_DATE_BOB, VALID_CREATED_DATE_BOB)
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
                 .build();

--- a/src/test/java/seedu/momentum/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/momentum/logic/commands/EditCommandTest.java
@@ -24,6 +24,7 @@ import seedu.momentum.model.Model;
 import seedu.momentum.model.ModelManager;
 import seedu.momentum.model.ProjectBook;
 import seedu.momentum.model.UserPrefs;
+import seedu.momentum.model.project.CompletionStatus;
 import seedu.momentum.model.project.Project;
 import seedu.momentum.model.project.TrackedItem;
 import seedu.momentum.testutil.EditTrackedItemDescriptorBuilder;
@@ -38,7 +39,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
-        Project editedProject = new ProjectBuilder().build();
+        Project editedProject = new ProjectBuilder().withCompletionStatus(CompletionStatus.COMPLETED).build();
         EditCommand.EditTrackedItemDescriptor descriptor = new EditTrackedItemDescriptorBuilder(editedProject).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PROJECT, descriptor);
 

--- a/src/test/java/seedu/momentum/logic/commands/EditTrackedItemDescriptorTest.java
+++ b/src/test/java/seedu/momentum/logic/commands/EditTrackedItemDescriptorTest.java
@@ -4,6 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.momentum.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.momentum.logic.commands.CommandTestUtil.DESC_BOB;
+import static seedu.momentum.logic.commands.CommandTestUtil.VALID_COMPLETION_STATUS_BOB;
+import static seedu.momentum.logic.commands.CommandTestUtil.VALID_CREATED_DATE_AMY;
+import static seedu.momentum.logic.commands.CommandTestUtil.VALID_DEADLINE_DATE_BOB;
 import static seedu.momentum.logic.commands.CommandTestUtil.VALID_DESCRIPTION_BOB;
 import static seedu.momentum.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.momentum.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
@@ -41,6 +44,16 @@ public class EditTrackedItemDescriptorTest {
         // different description -> returns false
         editedAmy = new EditTrackedItemDescriptorBuilder(DESC_AMY).withDescription(VALID_DESCRIPTION_BOB).build();
         assertFalse(DESC_AMY.equals(editedAmy));
+
+        // different completion status -> returns false
+        editedAmy = new EditTrackedItemDescriptorBuilder(DESC_AMY)
+                .withCompletionStatus(VALID_COMPLETION_STATUS_BOB).build();
+        assertFalse(DESC_AMY.equals(editedAmy));
+
+        // different deadline -> returns false
+        editedAmy = new EditTrackedItemDescriptorBuilder(DESC_AMY)
+                .withDeadline(VALID_DEADLINE_DATE_BOB, VALID_CREATED_DATE_AMY).build();
+        assertFalse(DESC_AMY.equals((editedAmy)));
 
         // different tags -> returns false
         editedAmy = new EditTrackedItemDescriptorBuilder(DESC_AMY).withTags(VALID_TAG_HUSBAND).build();

--- a/src/test/java/seedu/momentum/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/momentum/logic/commands/FindCommandTest.java
@@ -12,6 +12,7 @@ import static seedu.momentum.testutil.TypicalProjects.CARL;
 import static seedu.momentum.testutil.TypicalProjects.DANIEL;
 import static seedu.momentum.testutil.TypicalProjects.ELLE;
 import static seedu.momentum.testutil.TypicalProjects.FIONA;
+import static seedu.momentum.testutil.TypicalProjects.GEORGE;
 import static seedu.momentum.testutil.TypicalProjects.getTypicalProjectBook;
 
 import java.util.Arrays;
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import seedu.momentum.model.Model;
 import seedu.momentum.model.ModelManager;
 import seedu.momentum.model.UserPrefs;
+import seedu.momentum.model.project.predicates.CompletionStatusPredicate;
 import seedu.momentum.model.project.predicates.DescriptionContainsKeywordsPredicate;
 import seedu.momentum.model.project.predicates.FindType;
 import seedu.momentum.model.project.predicates.NameContainsKeywordsPredicate;
@@ -140,6 +142,17 @@ public class FindCommandTest {
     }
 
     @Test
+    public void anyMatch_singleCompletionStatusKeyword_multipleProjectsFound() {
+        String expectedMessage = String.format(MESSAGE_PROJECTS_LISTED_OVERVIEW, 3);
+        CompletionStatusPredicate predicate =
+                prepareCompletionStatusPredicate(FindType.ANY, CompletionStatusPredicate.COMPLETED_KEYWORD);
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredProjectList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(BENSON, CARL, GEORGE), model.getFilteredTrackedItemList());
+    }
+
+    @Test
     public void anyMatch_multipleTagKeywords_multipleProjectsFound() {
         String expectedMessage = String.format(MESSAGE_PROJECTS_LISTED_OVERVIEW, 3);
         TagListContainsKeywordsPredicate predicate = prepareTagListPredicate(FindType.ANY, TEST_TAGS);
@@ -171,7 +184,15 @@ public class FindCommandTest {
      */
     private DescriptionContainsKeywordsPredicate prepareDescriptionPredicate(FindType findType, String userInput) {
         return new DescriptionContainsKeywordsPredicate(findType,
-            Arrays.asList(userInput.split(FIND_ARGUMENT_DELIMITER)));
+                Arrays.asList(userInput.split(FIND_ARGUMENT_DELIMITER)));
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code CompletionStatusPredicate}.
+     */
+    private CompletionStatusPredicate prepareCompletionStatusPredicate(FindType findType, String userInput) {
+        return new CompletionStatusPredicate(findType,
+                Arrays.asList(userInput.split(FIND_ARGUMENT_DELIMITER)));
     }
 
     /**
@@ -179,6 +200,6 @@ public class FindCommandTest {
      */
     private TagListContainsKeywordsPredicate prepareTagListPredicate(FindType findType, String userInput) {
         return new TagListContainsKeywordsPredicate(findType,
-            Arrays.asList(userInput.split(FIND_ARGUMENT_DELIMITER)));
+                Arrays.asList(userInput.split(FIND_ARGUMENT_DELIMITER)));
     }
 }

--- a/src/test/java/seedu/momentum/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/momentum/logic/commands/SortCommandTest.java
@@ -11,11 +11,11 @@ import static seedu.momentum.logic.commands.SortCommand.OUTPUT_CREATED_TYPE;
 import static seedu.momentum.logic.commands.SortCommand.OUTPUT_DEADLINE_TYPE;
 import static seedu.momentum.logic.commands.SortCommand.OUTPUT_DEFAULT_TYPE;
 import static seedu.momentum.logic.commands.SortCommand.OUTPUT_DESCENDING_ORDER;
-import static seedu.momentum.testutil.SortCommandUtil.ALPHA_ASCENDING_COMMAND;
+import static seedu.momentum.testutil.SortCommandUtil.ALPHA_ASCENDING_COMMAND_WITH_COMPLETION_STATUS;
 import static seedu.momentum.testutil.SortCommandUtil.ALPHA_DESCENDING_COMMAND;
 import static seedu.momentum.testutil.SortCommandUtil.CREATED_DATE_ASCENDING_COMMAND;
-import static seedu.momentum.testutil.SortCommandUtil.CREATED_DATE_DESCENDING_COMMAND;
-import static seedu.momentum.testutil.SortCommandUtil.DEADLINE_ASCENDING_COMMAND;
+import static seedu.momentum.testutil.SortCommandUtil.CREATED_DATE_DESCENDING_COMMAND_WITH_COMPLETION_STATUS;
+import static seedu.momentum.testutil.SortCommandUtil.DEADLINE_ASCENDING_COMMAND_WITH_COMPLETION_STATUS;
 import static seedu.momentum.testutil.SortCommandUtil.DEADLINE_DESCENDING_COMMAND;
 import static seedu.momentum.testutil.SortCommandUtil.DEFAULT_SORT_COMMAND;
 import static seedu.momentum.testutil.SortCommandUtil.NULL_SORT_TYPE_ASCENDING_NON_DEFAULT_COMMAND;
@@ -36,43 +36,45 @@ public class SortCommandTest {
 
     private static final String EMPTY_STRING = "";
 
-    private Model model = new ModelManager(getTypicalProjectBook(), new UserPrefs());
-    private Model expectedModel = new ModelManager(getTypicalProjectBook(), new UserPrefs());
+    private static final Model model = new ModelManager(getTypicalProjectBook(), new UserPrefs());
+    private static final Model expectedModel = new ModelManager(getTypicalProjectBook(), new UserPrefs());
 
     @Test
     public void equals() {
 
         // same object -> returns true
-        assertTrue(ALPHA_ASCENDING_COMMAND.equals(ALPHA_ASCENDING_COMMAND));
+        assertTrue(ALPHA_ASCENDING_COMMAND_WITH_COMPLETION_STATUS
+                .equals(ALPHA_ASCENDING_COMMAND_WITH_COMPLETION_STATUS));
 
         // same values -> returns true
-        SortCommand alphaAscending = new SortCommand(SortType.ALPHA, true, false);
-        assertTrue(ALPHA_ASCENDING_COMMAND.equals(alphaAscending));
+        SortCommand alphaAscending = new SortCommand(SortType.ALPHA, true, false, true);
+        assertTrue(ALPHA_ASCENDING_COMMAND_WITH_COMPLETION_STATUS.equals(alphaAscending));
 
         // both default -> returns true
         // DEFAULT_SORT sort type is set to SortType.ALPHA
-        SortCommand defaultSort = new SortCommand(SortType.ALPHA, true, true);
+        SortCommand defaultSort = new SortCommand(SortType.ALPHA, true, true, true);
         assertTrue(DEFAULT_SORT_COMMAND.equals(defaultSort));
 
         // one default, one not default
-        assertFalse(ALPHA_ASCENDING_COMMAND.equals(DEFAULT_SORT_COMMAND));
+        assertFalse(ALPHA_ASCENDING_COMMAND_WITH_COMPLETION_STATUS.equals(DEFAULT_SORT_COMMAND));
 
         // different types -> returns false
-        assertFalse(ALPHA_ASCENDING_COMMAND.equals(1));
+        assertFalse(ALPHA_ASCENDING_COMMAND_WITH_COMPLETION_STATUS.equals(1));
 
         // null -> returns false
-        assertFalse(ALPHA_ASCENDING_COMMAND.equals(null));
+        assertFalse(ALPHA_ASCENDING_COMMAND_WITH_COMPLETION_STATUS.equals(null));
 
         // different sort types -> returns false
-        assertFalse(ALPHA_ASCENDING_COMMAND.equals(DEADLINE_ASCENDING_COMMAND));
+        assertFalse(ALPHA_ASCENDING_COMMAND_WITH_COMPLETION_STATUS
+                .equals(DEADLINE_ASCENDING_COMMAND_WITH_COMPLETION_STATUS));
 
         // different sort orders -> returns false
-        assertFalse(ALPHA_ASCENDING_COMMAND.equals(ALPHA_DESCENDING_COMMAND));
+        assertFalse(ALPHA_ASCENDING_COMMAND_WITH_COMPLETION_STATUS.equals(ALPHA_DESCENDING_COMMAND));
     }
 
     @Test
     public void execute_defaultSort_sortedInDefaultOrder() {
-        expectedModel.orderFilteredProjectList(SortType.ALPHA, true);
+        expectedModel.orderFilteredProjectList(SortType.ALPHA, true, true);
         String expectedMessage = String.format(MESSAGE_SORT_SUCCESS, EMPTY_STRING, OUTPUT_DEFAULT_TYPE);
         assertCommandSuccess(DEFAULT_SORT_COMMAND, model, expectedMessage, expectedModel);
         assertEquals(model.getFilteredTrackedItemList(), expectedModel.getFilteredTrackedItemList());
@@ -80,15 +82,15 @@ public class SortCommandTest {
 
     @Test
     public void execute_alphabeticalAscending_sortedInAlphabeticalAscendingOrder() {
-        expectedModel.orderFilteredProjectList(SortType.ALPHA, true);
+        expectedModel.orderFilteredProjectList(SortType.ALPHA, true, true);
         String expectedMessage = String.format(MESSAGE_SORT_SUCCESS, OUTPUT_ALPHA_TYPE, OUTPUT_ASCENDING_ORDER);
-        assertCommandSuccess(ALPHA_ASCENDING_COMMAND, model, expectedMessage, expectedModel);
+        assertCommandSuccess(ALPHA_ASCENDING_COMMAND_WITH_COMPLETION_STATUS, model, expectedMessage, expectedModel);
         assertEquals(model.getFilteredTrackedItemList(), expectedModel.getFilteredTrackedItemList());
     }
 
     @Test
     public void execute_alphabeticalDescending_sortedInAlphabeticalDescendingOrder() {
-        expectedModel.orderFilteredProjectList(SortType.ALPHA, false);
+        expectedModel.orderFilteredProjectList(SortType.ALPHA, false, false);
         String expectedMessage = String.format(MESSAGE_SORT_SUCCESS, OUTPUT_ALPHA_TYPE, OUTPUT_DESCENDING_ORDER);
         assertCommandSuccess(ALPHA_DESCENDING_COMMAND, model, expectedMessage, expectedModel);
         assertEquals(model.getFilteredTrackedItemList(), expectedModel.getFilteredTrackedItemList());
@@ -96,15 +98,15 @@ public class SortCommandTest {
 
     @Test
     public void execute_deadlineAscending_sortedInDeadlineAscendingOrder() {
-        expectedModel.orderFilteredProjectList(SortType.DEADLINE, true);
+        expectedModel.orderFilteredProjectList(SortType.DEADLINE, true, true);
         String expectedMessage = String.format(MESSAGE_SORT_SUCCESS, OUTPUT_DEADLINE_TYPE, OUTPUT_ASCENDING_ORDER);
-        assertCommandSuccess(DEADLINE_ASCENDING_COMMAND, model, expectedMessage, expectedModel);
+        assertCommandSuccess(DEADLINE_ASCENDING_COMMAND_WITH_COMPLETION_STATUS, model, expectedMessage, expectedModel);
         assertEquals(model.getFilteredTrackedItemList(), expectedModel.getFilteredTrackedItemList());
     }
 
     @Test
     public void execute_deadlineDescending_sortedInDeadlineDescendingOrder() {
-        expectedModel.orderFilteredProjectList(SortType.DEADLINE, false);
+        expectedModel.orderFilteredProjectList(SortType.DEADLINE, false, false);
         String expectedMessage = String.format(MESSAGE_SORT_SUCCESS, OUTPUT_DEADLINE_TYPE, OUTPUT_DESCENDING_ORDER);
         assertCommandSuccess(DEADLINE_DESCENDING_COMMAND, model, expectedMessage, expectedModel);
         assertEquals(model.getFilteredTrackedItemList(), expectedModel.getFilteredTrackedItemList());
@@ -112,7 +114,7 @@ public class SortCommandTest {
 
     @Test
     public void execute_createdDateAscending_sortedInCreatedDateAscendingOrder() {
-        expectedModel.orderFilteredProjectList(SortType.CREATED, true);
+        expectedModel.orderFilteredProjectList(SortType.CREATED, true, false);
         String expectedMessage = String.format(MESSAGE_SORT_SUCCESS, OUTPUT_CREATED_TYPE, OUTPUT_ASCENDING_ORDER);
         assertCommandSuccess(CREATED_DATE_ASCENDING_COMMAND, model, expectedMessage, expectedModel);
         assertEquals(model.getFilteredTrackedItemList(), expectedModel.getFilteredTrackedItemList());
@@ -120,25 +122,26 @@ public class SortCommandTest {
 
     @Test
     public void execute_createdDateDescending_sortedInCreatedDateDescendingOrder() {
-        expectedModel.orderFilteredProjectList(SortType.CREATED, false);
+        expectedModel.orderFilteredProjectList(SortType.CREATED, false, true);
         String expectedMessage = String.format(MESSAGE_SORT_SUCCESS, OUTPUT_CREATED_TYPE, OUTPUT_DESCENDING_ORDER);
-        assertCommandSuccess(CREATED_DATE_DESCENDING_COMMAND, model, expectedMessage, expectedModel);
+        assertCommandSuccess(CREATED_DATE_DESCENDING_COMMAND_WITH_COMPLETION_STATUS,
+                model, expectedMessage, expectedModel);
         assertEquals(model.getFilteredTrackedItemList(), expectedModel.getFilteredTrackedItemList());
     }
 
     @Test
     public void execute_nullSortTypeAscendingNonDefault_sortedInCurrentSortTypeAscendingOrder() {
-        model.orderFilteredProjectList(SortType.DEADLINE, false);
-        expectedModel.orderFilteredProjectList(SortType.DEADLINE, true);
+        model.orderFilteredProjectList(SortType.DEADLINE, false, true);
+        expectedModel.orderFilteredProjectList(SortType.DEADLINE, true, true);
         String expectedMessage = String.format(MESSAGE_SORT_SUCCESS, EMPTY_STRING, OUTPUT_ASCENDING_ORDER);
         assertCommandSuccess(NULL_SORT_TYPE_ASCENDING_NON_DEFAULT_COMMAND, model, expectedMessage, expectedModel);
         assertEquals(model.getFilteredTrackedItemList(), expectedModel.getFilteredTrackedItemList());
     }
 
     @Test
-    public void execute_nullSortTypeDescendingNonDefault_sortedInCurrentSortTypeDscendingOrder() {
-        model.orderFilteredProjectList(SortType.CREATED, true);
-        expectedModel.orderFilteredProjectList(SortType.CREATED, false);
+    public void execute_nullSortTypeDescendingNonDefault_sortedInCurrentSortTypeDescendingOrder() {
+        model.orderFilteredProjectList(SortType.CREATED, true, true);
+        expectedModel.orderFilteredProjectList(SortType.CREATED, false, true);
         String expectedMessage = String.format(MESSAGE_SORT_SUCCESS, EMPTY_STRING, OUTPUT_DESCENDING_ORDER);
         assertCommandSuccess(NULL_SORT_TYPE_DESCENDING_NON_DEFAULT_COMMAND, model, expectedMessage, expectedModel);
         assertEquals(model.getFilteredTrackedItemList(), expectedModel.getFilteredTrackedItemList());

--- a/src/test/java/seedu/momentum/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/momentum/logic/parser/AddCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.momentum.logic.parser;
 
 import static seedu.momentum.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.momentum.logic.commands.CommandTestUtil.COMPLETION_STATUS_DESC_BOB;
 import static seedu.momentum.logic.commands.CommandTestUtil.DEADLINE_DATE_DESC_AMY;
 import static seedu.momentum.logic.commands.CommandTestUtil.DEADLINE_DATE_DESC_BOB;
 import static seedu.momentum.logic.commands.CommandTestUtil.DEADLINE_TIME_DESC_AMY;
@@ -50,22 +51,36 @@ public class AddCommandParserTest {
                 .withCurrentCreatedDate().build();
 
         // whitespace only preamble
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + DESCRIPTION_DESC_BOB + DEADLINE_DATE_DESC_BOB
-                + TAG_DESC_FRIEND, new AddCommand(expectedProject), model);
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + DESCRIPTION_DESC_BOB
+                + COMPLETION_STATUS_DESC_BOB + DEADLINE_DATE_DESC_BOB + TAG_DESC_FRIEND,
+                new AddCommand(expectedProject), model);
 
         // multiple names - last name accepted
-        assertParseSuccess(parser, NAME_DESC_AMY + NAME_DESC_BOB + DESCRIPTION_DESC_BOB + DEADLINE_DATE_DESC_BOB
-                + TAG_DESC_FRIEND, new AddCommand(expectedProject), model);
+        assertParseSuccess(parser, NAME_DESC_AMY + NAME_DESC_BOB + DESCRIPTION_DESC_BOB
+                + COMPLETION_STATUS_DESC_BOB + DEADLINE_DATE_DESC_BOB + TAG_DESC_FRIEND,
+                new AddCommand(expectedProject), model);
 
         // multiple descriptions - last description accepted
-        assertParseSuccess(parser, NAME_DESC_BOB + DESCRIPTION_DESC_AMY + DESCRIPTION_DESC_BOB + DEADLINE_DATE_DESC_BOB
-                + TAG_DESC_FRIEND, new AddCommand(expectedProject), model);
+        assertParseSuccess(parser, NAME_DESC_BOB + DESCRIPTION_DESC_AMY + DESCRIPTION_DESC_BOB
+                + COMPLETION_STATUS_DESC_BOB + DEADLINE_DATE_DESC_BOB + TAG_DESC_FRIEND,
+                new AddCommand(expectedProject), model);
+
+        // multiple completion status
+        assertParseSuccess(parser, NAME_DESC_BOB + DESCRIPTION_DESC_BOB + COMPLETION_STATUS_DESC_BOB
+                + COMPLETION_STATUS_DESC_BOB + DEADLINE_DATE_DESC_BOB + TAG_DESC_FRIEND,
+                new AddCommand(expectedProject), model);
+
+        // multiple deadlines - last deadline accepted
+        assertParseSuccess(parser, NAME_DESC_BOB + DESCRIPTION_DESC_BOB + DEADLINE_DATE_DESC_AMY
+                + COMPLETION_STATUS_DESC_BOB + DEADLINE_DATE_DESC_BOB + TAG_DESC_FRIEND,
+                new AddCommand(expectedProject), model);
 
         // multiple tags - all accepted
         Project expectedProjectMultipleTags = new ProjectBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
                 .withCurrentCreatedDate().build();
-        assertParseSuccess(parser, NAME_DESC_BOB + DESCRIPTION_DESC_BOB + DEADLINE_DATE_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, new AddCommand(expectedProjectMultipleTags), model);
+        assertParseSuccess(parser, NAME_DESC_BOB + DESCRIPTION_DESC_BOB + COMPLETION_STATUS_DESC_BOB
+                + DEADLINE_DATE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                new AddCommand(expectedProjectMultipleTags), model);
     }
 
     @Test

--- a/src/test/java/seedu/momentum/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/momentum/logic/parser/EditCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.momentum.logic.parser;
 
 import static seedu.momentum.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.momentum.logic.commands.CommandTestUtil.COMPLETION_STATUS_DESC_BOB;
 import static seedu.momentum.logic.commands.CommandTestUtil.DEADLINE_DATE_DESC_AMY;
 import static seedu.momentum.logic.commands.CommandTestUtil.DEADLINE_DATE_DESC_BOB;
 import static seedu.momentum.logic.commands.CommandTestUtil.DEADLINE_TIME_DESC_AMY;
@@ -13,6 +14,7 @@ import static seedu.momentum.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.momentum.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.momentum.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.momentum.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.momentum.logic.commands.CommandTestUtil.VALID_COMPLETION_STATUS_AMY;
 import static seedu.momentum.logic.commands.CommandTestUtil.VALID_CREATED_DATE_AMY;
 import static seedu.momentum.logic.commands.CommandTestUtil.VALID_CREATED_DATE_BOB;
 import static seedu.momentum.logic.commands.CommandTestUtil.VALID_DEADLINE_DATE_AMY;
@@ -40,6 +42,7 @@ import seedu.momentum.logic.commands.EditCommand;
 import seedu.momentum.model.Model;
 import seedu.momentum.model.ModelManager;
 import seedu.momentum.model.UserPrefs;
+import seedu.momentum.model.project.CompletionStatus;
 import seedu.momentum.model.project.Name;
 import seedu.momentum.model.tag.Tag;
 import seedu.momentum.testutil.EditTrackedItemDescriptorBuilder;
@@ -112,11 +115,12 @@ public class EditCommandParserTest {
     public void parse_allFieldsSpecified_success() {
         Index targetIndex = INDEX_SECOND_PROJECT;
         String userInput = targetIndex.getOneBased() + TAG_DESC_HUSBAND + NAME_DESC_AMY + DESCRIPTION_DESC_AMY
-                + DEADLINE_DATE_DESC_AMY + DEADLINE_TIME_DESC_AMY + TAG_DESC_FRIEND;
+                + COMPLETION_STATUS_DESC_BOB + DEADLINE_DATE_DESC_AMY + DEADLINE_TIME_DESC_AMY + TAG_DESC_FRIEND;
 
         EditCommand.EditTrackedItemDescriptor descriptor =
             new EditTrackedItemDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withDescription(VALID_DESCRIPTION_AMY)
+                .withCompletionStatus(VALID_COMPLETION_STATUS_AMY)
                 .withDeadline(VALID_DEADLINE_DATE_AMY, VALID_DEADLINE_TIME_AMY, VALID_CREATED_DATE_AMY)
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
@@ -149,6 +153,12 @@ public class EditCommandParserTest {
         // description
         userInput = targetIndex.getOneBased() + DESCRIPTION_DESC_AMY;
         descriptor = new EditTrackedItemDescriptorBuilder().withDescription(VALID_DESCRIPTION_AMY).build();
+        expectedCommand = new EditCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand, model);
+
+        // completion status
+        userInput = targetIndex.getOneBased() + COMPLETION_STATUS_DESC_BOB;
+        descriptor = new EditTrackedItemDescriptorBuilder().withCompletionStatus(new CompletionStatus()).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand, model);
 

--- a/src/test/java/seedu/momentum/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/momentum/logic/parser/FindCommandParserTest.java
@@ -2,6 +2,7 @@ package seedu.momentum.logic.parser;
 
 import static seedu.momentum.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.momentum.logic.parser.CliSyntax.FIND_TYPE;
+import static seedu.momentum.logic.parser.CliSyntax.PREFIX_COMPLETION_STATUS;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_TAG;
@@ -18,6 +19,7 @@ import seedu.momentum.logic.commands.FindCommand;
 import seedu.momentum.model.Model;
 import seedu.momentum.model.ModelManager;
 import seedu.momentum.model.UserPrefs;
+import seedu.momentum.model.project.predicates.CompletionStatusPredicate;
 import seedu.momentum.model.project.predicates.DescriptionContainsKeywordsPredicate;
 import seedu.momentum.model.project.predicates.FindType;
 import seedu.momentum.model.project.predicates.NameContainsKeywordsPredicate;
@@ -49,6 +51,11 @@ public class FindCommandParserTest {
 
         // prefixes (other than /match) missing
         assertParseFailure(parser, FIND_TYPE + "all",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE), model);
+
+        // > 1 keyword for completion status
+        assertParseFailure(parser, String.format("%s %s %s %s %s", FIND_TYPE, "any", PREFIX_COMPLETION_STATUS,
+                CompletionStatusPredicate.COMPLETED_KEYWORD, CompletionStatusPredicate.INCOMPLETE_KEYWORD),
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE), model);
     }
 

--- a/src/test/java/seedu/momentum/logic/parser/ProjectBookParserTest.java
+++ b/src/test/java/seedu/momentum/logic/parser/ProjectBookParserTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.momentum.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.momentum.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.momentum.logic.commands.SortCommand.INPUT_ALPHA_TYPE;
+import static seedu.momentum.logic.parser.CliSyntax.PREFIX_COMPLETION_STATUS;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.momentum.logic.parser.CliSyntax.SORT_ORDER;
 import static seedu.momentum.logic.parser.CliSyntax.SORT_TYPE;
@@ -93,8 +94,9 @@ public class ProjectBookParserTest {
     public void parseCommand_sort() throws Exception {
         assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD, model) instanceof SortCommand);
         SortCommand command = (SortCommand) parser.parseCommand(SortCommand.COMMAND_WORD + " "
-                + SORT_ORDER + SortCommand.INPUT_ASCENDING_ORDER + " " + SORT_TYPE + INPUT_ALPHA_TYPE, model);
-        assertEquals(new SortCommand(SortType.ALPHA, true, false), command);
+                + SORT_ORDER + SortCommand.INPUT_ASCENDING_ORDER + " " + SORT_TYPE + INPUT_ALPHA_TYPE + " "
+                + PREFIX_COMPLETION_STATUS, model);
+        assertEquals(new SortCommand(SortType.ALPHA, true, false, false), command);
     }
 
     @Test

--- a/src/test/java/seedu/momentum/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/momentum/logic/parser/SortCommandParserTest.java
@@ -9,12 +9,13 @@ import static seedu.momentum.logic.commands.CommandTestUtil.VALID_ASCENDING_SORT
 import static seedu.momentum.logic.commands.CommandTestUtil.VALID_CREATED_DATE_SORT_TYPE;
 import static seedu.momentum.logic.commands.CommandTestUtil.VALID_DEADLINE_SORT_TYPE;
 import static seedu.momentum.logic.commands.CommandTestUtil.VALID_DESCENDING_SORT_ORDER;
+import static seedu.momentum.logic.parser.CliSyntax.PREFIX_COMPLETION_STATUS;
 import static seedu.momentum.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.momentum.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.momentum.testutil.SortCommandUtil.ALPHA_ASCENDING_COMMAND;
+import static seedu.momentum.testutil.SortCommandUtil.ALPHA_ASCENDING_COMMAND_WITH_COMPLETION_STATUS;
 import static seedu.momentum.testutil.SortCommandUtil.ALPHA_DESCENDING_COMMAND;
 import static seedu.momentum.testutil.SortCommandUtil.CREATED_DATE_ASCENDING_COMMAND;
-import static seedu.momentum.testutil.SortCommandUtil.DEADLINE_ASCENDING_COMMAND;
+import static seedu.momentum.testutil.SortCommandUtil.DEADLINE_ASCENDING_COMMAND_WITH_COMPLETION_STATUS;
 import static seedu.momentum.testutil.SortCommandUtil.NULL_SORT_TYPE_ASCENDING_NON_DEFAULT_COMMAND;
 import static seedu.momentum.testutil.SortCommandUtil.NULL_SORT_TYPE_DESCENDING_NON_DEFAULT_COMMAND;
 import static seedu.momentum.testutil.TypicalProjects.getTypicalProjectBook;
@@ -34,7 +35,7 @@ public class SortCommandParserTest {
     private static final String MESSAGE_NON_EMPTY_PREAMBLE_FAILURE = String.format(
             MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE);
     private static final SortCommand DEFAULT_SORT_COMMAND =
-            new SortCommand(SortType.NULL, true, true);
+            new SortCommand(SortType.NULL, true, true, true);
 
     private final SortCommandParser parser = new SortCommandParser();
     private Model model = new ModelManager(getTypicalProjectBook(), new UserPrefs());
@@ -57,12 +58,11 @@ public class SortCommandParserTest {
 
     @Test
     public void parse_missingSortOrder_returnsTypedAscendingSortCommand() {
-
         // Alphabetical type
-        assertParseSuccess(parser, VALID_ALPHA_SORT_TYPE, ALPHA_ASCENDING_COMMAND, model);
+        assertParseSuccess(parser, VALID_ALPHA_SORT_TYPE, ALPHA_ASCENDING_COMMAND_WITH_COMPLETION_STATUS, model);
 
         // Deadline type
-        assertParseSuccess(parser, VALID_DEADLINE_SORT_TYPE, DEADLINE_ASCENDING_COMMAND, model);
+        assertParseSuccess(parser, VALID_DEADLINE_SORT_TYPE, DEADLINE_ASCENDING_COMMAND_WITH_COMPLETION_STATUS, model);
 
         // Created date type
         assertParseSuccess(parser, VALID_CREATED_DATE_SORT_TYPE, CREATED_DATE_ASCENDING_COMMAND, model);
@@ -71,7 +71,7 @@ public class SortCommandParserTest {
 
     @Test
     public void parse_allFieldsSpecified_returnsSortCommand() {
-        String userInput = VALID_ALPHA_SORT_TYPE + VALID_DESCENDING_SORT_ORDER;
+        String userInput = VALID_ALPHA_SORT_TYPE + VALID_DESCENDING_SORT_ORDER + " " + PREFIX_COMPLETION_STATUS;
         assertParseSuccess(parser, userInput, ALPHA_DESCENDING_COMMAND, model);
     }
 

--- a/src/test/java/seedu/momentum/model/ProjectBookTest.java
+++ b/src/test/java/seedu/momentum/model/ProjectBookTest.java
@@ -61,8 +61,7 @@ public class ProjectBookTest {
 
     @Test
     public void setOrder_withSortTypeNull_throwsNullPointerException() {
-        boolean isAscending = true;
-        assertThrows(NullPointerException.class, () -> projectBook.setOrder(null, isAscending));
+        assertThrows(NullPointerException.class, () -> projectBook.setOrder(null, true, true));
     }
 
     @Test
@@ -70,7 +69,7 @@ public class ProjectBookTest {
         ProjectBook unorderedProjectBook = getTypicalProjectBook();
         ProjectBook orderedProjectBook = new ProjectBook();
         orderedProjectBook.setTrackedItems(getOrderedProjectBookByDeadlineAscending());
-        unorderedProjectBook.setOrder(SortType.DEADLINE, true);
+        unorderedProjectBook.setOrder(SortType.DEADLINE, true, false);
         assertEquals(orderedProjectBook, unorderedProjectBook);
     }
 

--- a/src/test/java/seedu/momentum/model/project/CompletionStatusTest.java
+++ b/src/test/java/seedu/momentum/model/project/CompletionStatusTest.java
@@ -1,0 +1,24 @@
+package seedu.momentum.model.project;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class CompletionStatusTest {
+    private static final CompletionStatus incomplete = new CompletionStatus();
+    private static final CompletionStatus completed = incomplete.reverse();
+
+    @Test
+    public void isCompleted() {
+        assertFalse(incomplete.isCompleted());
+        assertTrue(completed.isCompleted());
+    }
+
+    @Test
+    public void reverse() {
+        assertEquals(incomplete.reverse(), completed);
+        assertEquals(completed.reverse(), incomplete);
+    }
+}

--- a/src/test/java/seedu/momentum/model/project/ProjectTest.java
+++ b/src/test/java/seedu/momentum/model/project/ProjectTest.java
@@ -2,6 +2,7 @@ package seedu.momentum.model.project;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.momentum.logic.commands.CommandTestUtil.VALID_COMPLETION_STATUS_BOB;
 import static seedu.momentum.logic.commands.CommandTestUtil.VALID_CREATED_DATE_AMY;
 import static seedu.momentum.logic.commands.CommandTestUtil.VALID_CREATED_DATE_BOB;
 import static seedu.momentum.logic.commands.CommandTestUtil.VALID_DEADLINE_DATE_AMY;
@@ -34,12 +35,16 @@ public class ProjectTest {
         // null -> returns false
         assertFalse(ALICE.isSameTrackedItem(null));
 
-        // different description -> returns false
-        Project editedAlice = new ProjectBuilder(ALICE).withDescription(VALID_DESCRIPTION_BOB).build();
+        // different name -> returns false
+        Project editedAlice = new ProjectBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertFalse(ALICE.isSameTrackedItem(editedAlice));
 
-        // different name -> returns false
-        editedAlice = new ProjectBuilder(ALICE).withName(VALID_NAME_BOB).build();
+        // different description -> returns false
+        editedAlice = new ProjectBuilder(ALICE).withDescription(VALID_DESCRIPTION_BOB).build();
+        assertFalse(ALICE.isSameTrackedItem(editedAlice));
+
+        // different completion status -> returns false
+        editedAlice = new ProjectBuilder(ALICE).withCompletionStatus(VALID_COMPLETION_STATUS_BOB).build();
         assertFalse(ALICE.isSameTrackedItem(editedAlice));
 
         // different created date -> returns false
@@ -93,6 +98,10 @@ public class ProjectTest {
 
         // different description -> returns false
         editedAlice = new ProjectBuilder(ALICE).withDescription(VALID_DESCRIPTION_BOB).build();
+        assertFalse(ALICE.equals(editedAlice));
+
+        // different completion status -> returns false
+        editedAlice = new ProjectBuilder(ALICE).withCompletionStatus(VALID_COMPLETION_STATUS_BOB).build();
         assertFalse(ALICE.equals(editedAlice));
 
         // different created date -> returns false

--- a/src/test/java/seedu/momentum/model/project/UniqueTrackedItemListTest.java
+++ b/src/test/java/seedu/momentum/model/project/UniqueTrackedItemListTest.java
@@ -167,7 +167,7 @@ public class UniqueTrackedItemListTest {
 
     @Test
     public void setOrder_nullSortType_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> uniqueTrackedItemList.setOrder(null, true));
+        assertThrows(NullPointerException.class, () -> uniqueTrackedItemList.setOrder(null, true, true));
     }
 
     @Test
@@ -175,7 +175,7 @@ public class UniqueTrackedItemListTest {
         for (Project p : getTypicalProjects()) {
             uniqueTrackedItemList.add(p);
         }
-        uniqueTrackedItemList.setOrder(SortType.ALPHA, true);
+        uniqueTrackedItemList.setOrder(SortType.ALPHA, true, false);
         UniqueTrackedItemList expectedUniqueTrackedItemList = TypicalProjectsOrders
                 .getUniqueProjectList(TypicalProjectsOrders.getOrderedProjectBookByAlphabeticalAscending());
         assertEquals(uniqueTrackedItemList, expectedUniqueTrackedItemList);
@@ -187,7 +187,7 @@ public class UniqueTrackedItemListTest {
         for (Project p : getTypicalProjects()) {
             uniqueTrackedItemList.add(p);
         }
-        uniqueTrackedItemList.setOrder(SortType.ALPHA, false);
+        uniqueTrackedItemList.setOrder(SortType.ALPHA, false, false);
         UniqueTrackedItemList expectedUniqueTrackedItemList = TypicalProjectsOrders
                 .getUniqueProjectList(TypicalProjectsOrders.getOrderedProjectBookByAlphabeticalDescending());
         assertEquals(uniqueTrackedItemList, expectedUniqueTrackedItemList);
@@ -199,7 +199,7 @@ public class UniqueTrackedItemListTest {
         for (Project p : getTypicalProjects()) {
             uniqueTrackedItemList.add(p);
         }
-        uniqueTrackedItemList.setOrder(SortType.DEADLINE, true);
+        uniqueTrackedItemList.setOrder(SortType.DEADLINE, true, false);
         UniqueTrackedItemList expectedUniqueTrackedItemList = TypicalProjectsOrders
                 .getUniqueProjectList(TypicalProjectsOrders.getOrderedProjectBookByDeadlineAscending());
         assertEquals(uniqueTrackedItemList, expectedUniqueTrackedItemList);
@@ -211,7 +211,7 @@ public class UniqueTrackedItemListTest {
         for (Project p : getTypicalProjects()) {
             uniqueTrackedItemList.add(p);
         }
-        uniqueTrackedItemList.setOrder(SortType.DEADLINE, false);
+        uniqueTrackedItemList.setOrder(SortType.DEADLINE, false, false);
         UniqueTrackedItemList expectedUniqueTrackedItemList = TypicalProjectsOrders
                 .getUniqueProjectList(TypicalProjectsOrders.getOrderedProjectBookByDeadlineDescending());
         assertEquals(uniqueTrackedItemList, expectedUniqueTrackedItemList);
@@ -223,7 +223,7 @@ public class UniqueTrackedItemListTest {
         for (Project p : getTypicalProjects()) {
             uniqueTrackedItemList.add(p);
         }
-        uniqueTrackedItemList.setOrder(SortType.CREATED, true);
+        uniqueTrackedItemList.setOrder(SortType.CREATED, true, false);
         UniqueTrackedItemList expectedUniqueTrackedItemList = TypicalProjectsOrders
                 .getUniqueProjectList(TypicalProjectsOrders.getOrderedProjectBookByCreatedDateAscending());
         assertEquals(uniqueTrackedItemList, expectedUniqueTrackedItemList);
@@ -234,7 +234,7 @@ public class UniqueTrackedItemListTest {
         for (Project p : getTypicalProjects()) {
             uniqueTrackedItemList.add(p);
         }
-        uniqueTrackedItemList.setOrder(SortType.CREATED, false);
+        uniqueTrackedItemList.setOrder(SortType.CREATED, false, false);
         UniqueTrackedItemList expectedUniqueTrackedItemList = TypicalProjectsOrders
                 .getUniqueProjectList(TypicalProjectsOrders.getOrderedProjectBookByCreatedDateDescending());
         assertEquals(uniqueTrackedItemList, expectedUniqueTrackedItemList);

--- a/src/test/java/seedu/momentum/model/project/predicates/CompletionStatusPredicateTest.java
+++ b/src/test/java/seedu/momentum/model/project/predicates/CompletionStatusPredicateTest.java
@@ -1,0 +1,74 @@
+package seedu.momentum.model.project.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.momentum.testutil.Assert.assertThrows;
+import static seedu.momentum.testutil.TypicalProjects.ALICE;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class CompletionStatusPredicateTest {
+
+    private static final List<String> COMPLETED_KEYWORD =
+            Collections.singletonList(CompletionStatusPredicate.COMPLETED_KEYWORD);
+    private static final List<String> INCOMPLETE_KEYWORD =
+            Collections.singletonList(CompletionStatusPredicate.INCOMPLETE_KEYWORD);
+    private static final List<String> MULTIPLE_KEYWORDS = Arrays.asList(CompletionStatusPredicate.COMPLETED_KEYWORD,
+            CompletionStatusPredicate.INCOMPLETE_KEYWORD);
+    private static final List<String> NO_MATCHING_KEYWORD = Arrays.asList("asfsfd");
+
+    private static final CompletionStatusPredicate isCompletedPredicateAny =
+            new CompletionStatusPredicate(FindType.ANY, COMPLETED_KEYWORD);
+    private static final CompletionStatusPredicate isCompletedPredicateAll =
+            new CompletionStatusPredicate(FindType.ALL, COMPLETED_KEYWORD);
+    private static final CompletionStatusPredicate isIncompletePredicateAny =
+            new CompletionStatusPredicate(FindType.ANY, INCOMPLETE_KEYWORD);
+    private static final CompletionStatusPredicate isIncompletePredicateAll =
+            new CompletionStatusPredicate(FindType.ALL, INCOMPLETE_KEYWORD);
+
+    @Test
+    public void constructor_assertionError() {
+        // Multiple keywords -> assertion error
+        assertThrows(AssertionError.class, () -> new CompletionStatusPredicate(FindType.ANY,
+                MULTIPLE_KEYWORDS));
+
+    }
+
+    @Test
+    public void equals() {
+        // same object -> returns true
+        assertTrue(isCompletedPredicateAny.equals(isCompletedPredicateAny));
+        assertTrue(isIncompletePredicateAll.equals(isIncompletePredicateAll));
+
+        // same keywords -> returns true
+        assertTrue(isCompletedPredicateAny.equals(isCompletedPredicateAll));
+        assertTrue(isIncompletePredicateAll.equals(isIncompletePredicateAny));
+
+        // different types -> returns false
+        assertFalse(isCompletedPredicateAny.equals(1));
+        assertFalse(isIncompletePredicateAll.equals(1));
+
+        // null -> returns false
+        assertFalse(isIncompletePredicateAny.equals(null));
+        assertFalse(isCompletedPredicateAll.equals(null));
+
+        // different predicate -> returns false
+        assertFalse(isCompletedPredicateAll.equals(isIncompletePredicateAll));
+        assertFalse(isCompletedPredicateAny.equals(isIncompletePredicateAny));
+    }
+
+    @Test
+    public void test() {
+        assertTrue(isIncompletePredicateAll.test(ALICE));
+        assertFalse(isCompletedPredicateAny.test(ALICE));
+
+        // No matching keyword -> return false
+        CompletionStatusPredicate noMatchingKeywordsPredicate = new CompletionStatusPredicate(FindType.ANY,
+                NO_MATCHING_KEYWORD);
+        assertFalse(noMatchingKeywordsPredicate.test(ALICE));
+    }
+}

--- a/src/test/java/seedu/momentum/model/project/predicates/DescriptionContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/momentum/model/project/predicates/DescriptionContainsKeywordsPredicateTest.java
@@ -55,7 +55,7 @@ public class DescriptionContainsKeywordsPredicateTest {
         assertFalse(firstAnyPredicate.equals(null));
         assertFalse(firstAllPredicate.equals(null));
 
-        // different project -> returns false
+        // different predicate -> returns false
         assertFalse(firstAnyPredicate.equals(secondAnyPredicate));
         assertFalse(firstAllPredicate.equals(secondAllPredicate));
     }

--- a/src/test/java/seedu/momentum/storage/JsonAdaptedProjectTest.java
+++ b/src/test/java/seedu/momentum/storage/JsonAdaptedProjectTest.java
@@ -26,6 +26,7 @@ public class JsonAdaptedProjectTest {
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_DESCRIPTION = BENSON.getDescription().toString();
+    private static final boolean VALID_COMPLETION_STATUS = BENSON.getCompletionStatus().isCompleted();
     private static final String VALID_CREATED_DATE = BENSON.getCreatedDate().toString();
     private static final JsonAdaptedDeadline VALID_DEADLINE = new JsonAdaptedDeadline(BENSON.getDeadline());
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
@@ -43,24 +44,24 @@ public class JsonAdaptedProjectTest {
 
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
-        JsonAdaptedProject project = new JsonAdaptedProject(INVALID_NAME, VALID_DESCRIPTION, VALID_CREATED_DATE,
-                VALID_DEADLINE, VALID_TAGS, VALID_DURATIONS, VALID_TIMER);
+        JsonAdaptedProject project = new JsonAdaptedProject(INVALID_NAME, VALID_DESCRIPTION, VALID_COMPLETION_STATUS,
+                VALID_CREATED_DATE, VALID_DEADLINE, VALID_TAGS, VALID_DURATIONS, VALID_TIMER);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, project::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedProject project = new JsonAdaptedProject(null, VALID_DESCRIPTION, VALID_CREATED_DATE,
-                VALID_DEADLINE, VALID_TAGS, VALID_DURATIONS, VALID_TIMER);
+        JsonAdaptedProject project = new JsonAdaptedProject(null, VALID_DESCRIPTION, VALID_COMPLETION_STATUS,
+                VALID_CREATED_DATE, VALID_DEADLINE, VALID_TAGS, VALID_DURATIONS, VALID_TIMER);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, project::toModelType);
     }
 
     @Test
     public void toModelType_invalidCreatedDate_throwsIllegalValueException() {
-        JsonAdaptedProject project = new JsonAdaptedProject(VALID_NAME, VALID_DESCRIPTION, INVALID_CREATED_DATE,
-                VALID_DEADLINE, VALID_TAGS, VALID_DURATIONS, VALID_TIMER);
+        JsonAdaptedProject project = new JsonAdaptedProject(VALID_NAME, VALID_DESCRIPTION, VALID_COMPLETION_STATUS,
+                INVALID_CREATED_DATE, VALID_DEADLINE, VALID_TAGS, VALID_DURATIONS, VALID_TIMER);
         String expectedMessage = Date.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, project::toModelType);
     }
@@ -69,8 +70,8 @@ public class JsonAdaptedProjectTest {
     public void toModelType_invalidDeadline_throwsIllegalValueException() {
         JsonAdaptedDeadline invalidJsonAdaptedDeadline =
                 new JsonAdaptedDeadline(INVALID_DEADLINE_DATE, INVALID_DEADLINE_TIME);
-        JsonAdaptedProject project = new JsonAdaptedProject(VALID_NAME, VALID_DESCRIPTION, INVALID_CREATED_DATE,
-                invalidJsonAdaptedDeadline, VALID_TAGS, VALID_DURATIONS, VALID_TIMER);
+        JsonAdaptedProject project = new JsonAdaptedProject(VALID_NAME, VALID_DESCRIPTION, VALID_COMPLETION_STATUS,
+                INVALID_CREATED_DATE, invalidJsonAdaptedDeadline, VALID_TAGS, VALID_DURATIONS, VALID_TIMER);
         String expectedMessage = Date.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, project::toModelType);
     }
@@ -80,8 +81,8 @@ public class JsonAdaptedProjectTest {
     public void toModelType_invalidTags_throwsIllegalValueException() {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
-        JsonAdaptedProject project = new JsonAdaptedProject(VALID_NAME, VALID_DESCRIPTION, VALID_CREATED_DATE,
-                VALID_DEADLINE, invalidTags, VALID_DURATIONS, VALID_TIMER);
+        JsonAdaptedProject project = new JsonAdaptedProject(VALID_NAME, VALID_DESCRIPTION, VALID_COMPLETION_STATUS,
+                VALID_CREATED_DATE, VALID_DEADLINE, invalidTags, VALID_DURATIONS, VALID_TIMER);
         assertThrows(IllegalValueException.class, project::toModelType);
     }
 
@@ -89,8 +90,8 @@ public class JsonAdaptedProjectTest {
     public void toModelType_invalidDurations_throwsIllegalValueException() {
         List<JsonAdaptedWorkDuration> invalidDurations = new ArrayList<>(VALID_DURATIONS);
         invalidDurations.add(new JsonAdaptedWorkDuration(INVALID_START_TIME, INVALID_STOP_TIME));
-        JsonAdaptedProject project = new JsonAdaptedProject(VALID_NAME, VALID_DESCRIPTION, VALID_CREATED_DATE,
-                VALID_DEADLINE, VALID_TAGS, invalidDurations, VALID_TIMER);
+        JsonAdaptedProject project = new JsonAdaptedProject(VALID_NAME, VALID_DESCRIPTION, VALID_COMPLETION_STATUS,
+                VALID_CREATED_DATE, VALID_DEADLINE, VALID_TAGS, invalidDurations, VALID_TIMER);
         assertThrows(IllegalValueException.class, project::toModelType);
     }
 }

--- a/src/test/java/seedu/momentum/testutil/EditTrackedItemDescriptorBuilder.java
+++ b/src/test/java/seedu/momentum/testutil/EditTrackedItemDescriptorBuilder.java
@@ -6,6 +6,7 @@ import java.util.stream.Stream;
 
 import seedu.momentum.commons.core.Date;
 import seedu.momentum.logic.commands.EditCommand;
+import seedu.momentum.model.project.CompletionStatus;
 import seedu.momentum.model.project.Deadline;
 import seedu.momentum.model.project.Description;
 import seedu.momentum.model.project.Name;
@@ -33,6 +34,7 @@ public class EditTrackedItemDescriptorBuilder {
     public EditTrackedItemDescriptorBuilder(TrackedItem trackedItem) {
         descriptor = new EditCommand.EditTrackedItemDescriptor();
         descriptor.setName(trackedItem.getName());
+        descriptor.setCompletionStatus(trackedItem.getCompletionStatus());
         descriptor.setDescription(trackedItem.getDescription());
         descriptor.setDeadline(trackedItem.getDeadline());
         descriptor.setTags(trackedItem.getTags());
@@ -51,6 +53,14 @@ public class EditTrackedItemDescriptorBuilder {
      */
     public EditTrackedItemDescriptorBuilder withDescription(String description) {
         descriptor.setDescription(new Description(description));
+        return this;
+    }
+
+    /**
+     * Sets the {@code CompletionStatus} of the {@code EditTrackedItemDescriptor} that we are building.
+     */
+    public EditTrackedItemDescriptorBuilder withCompletionStatus(CompletionStatus completionStatus) {
+        descriptor.setCompletionStatus(completionStatus);
         return this;
     }
 

--- a/src/test/java/seedu/momentum/testutil/ProjectBuilder.java
+++ b/src/test/java/seedu/momentum/testutil/ProjectBuilder.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import seedu.momentum.commons.core.Clock;
 import seedu.momentum.commons.core.Date;
+import seedu.momentum.model.project.CompletionStatus;
 import seedu.momentum.model.project.Deadline;
 import seedu.momentum.model.project.Description;
 import seedu.momentum.model.project.Name;
@@ -29,6 +30,7 @@ public class ProjectBuilder {
 
     private Name name;
     private Description description;
+    private CompletionStatus completionStatus;
     private Date createdDate;
     private Deadline deadline;
     private Set<Tag> tags;
@@ -41,6 +43,7 @@ public class ProjectBuilder {
     public ProjectBuilder() {
         name = new Name(DEFAULT_NAME);
         description = new Description(DEFAULT_DESCRIPTION);
+        completionStatus = new CompletionStatus();
         createdDate = new Date(DEFAULT_CREATED_DATE);
         deadline = new Deadline(DEFAULT_DEADLINE_DATE, DEFAULT_DEADLINE_TIME, createdDate);
         tags = new HashSet<>();
@@ -51,17 +54,18 @@ public class ProjectBuilder {
     /**
      * Initializes the ProjectBuilder with the data of {@code projectToCopy}.
      */
-    public ProjectBuilder(TrackedItem projectToCopy) {
-        name = projectToCopy.getName();
-        description = projectToCopy.getDescription();
-        createdDate = projectToCopy.getCreatedDate();
-        deadline = projectToCopy.getDeadline();
-        tags = new HashSet<>(projectToCopy.getTags());
+    public ProjectBuilder(TrackedItem trackedItemToCopy) {
+        name = trackedItemToCopy.getName();
+        description = trackedItemToCopy.getDescription();
+        completionStatus = trackedItemToCopy.getCompletionStatus();
+        createdDate = trackedItemToCopy.getCreatedDate();
+        deadline = trackedItemToCopy.getDeadline();
+        tags = new HashSet<>(trackedItemToCopy.getTags());
         durations = new UniqueDurationList();
-        for (WorkDuration duration : projectToCopy.getDurationList()) {
+        for (WorkDuration duration : trackedItemToCopy.getDurationList()) {
             durations.add(duration);
         }
-        timer = projectToCopy.getTimer();
+        timer = trackedItemToCopy.getTimer();
     }
 
     /**
@@ -77,6 +81,14 @@ public class ProjectBuilder {
      */
     public ProjectBuilder withDescription(String description) {
         this.description = new Description(description);
+        return this;
+    }
+
+    /**
+     * Sets the {@code CompletionStatus} of the {@code Project} that we are building.
+     */
+    public ProjectBuilder withCompletionStatus(CompletionStatus completionStatus) {
+        this.completionStatus = completionStatus;
         return this;
     }
 
@@ -155,6 +167,6 @@ public class ProjectBuilder {
     }
 
     public Project build() {
-        return new Project(name, description, createdDate, deadline, tags, durations, timer);
+        return new Project(name, description, completionStatus, createdDate, deadline, tags, durations, timer);
     }
 }

--- a/src/test/java/seedu/momentum/testutil/ProjectUtil.java
+++ b/src/test/java/seedu/momentum/testutil/ProjectUtil.java
@@ -1,5 +1,6 @@
 package seedu.momentum.testutil;
 
+import static seedu.momentum.logic.parser.CliSyntax.PREFIX_COMPLETION_STATUS;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_DEADLINE_DATE;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_DEADLINE_TIME;
 import static seedu.momentum.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
@@ -33,6 +34,9 @@ public class ProjectUtil {
         StringBuilder sb = new StringBuilder();
         sb.append(PREFIX_NAME + project.getName().fullName + " ");
         sb.append(PREFIX_DESCRIPTION + project.getDescription().value + " ");
+        if (project.getCompletionStatus().isCompleted()) {
+            sb.append(PREFIX_COMPLETION_STATUS + " ");
+        }
         Deadline deadline = project.getDeadline();
         if (!deadline.isEmpty()) {
             sb.append(PREFIX_DEADLINE_DATE + deadline.getDate().toString() + " ");
@@ -54,6 +58,8 @@ public class ProjectUtil {
         descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName).append(" "));
         descriptor.getDescription().ifPresent(description -> sb.append(PREFIX_DESCRIPTION).append(description.value)
                 .append(" "));
+        descriptor.getCompletionStatus().ifPresent(editedCompletionStatus
+            -> sb.append(PREFIX_COMPLETION_STATUS).append(" "));
         if (descriptor.getDeadline().isPresent() && !descriptor.getDeadline().isEmpty()) {
             Deadline deadline = descriptor.getDeadline().get();
             sb.append(PREFIX_DEADLINE_DATE + deadline.getDate().toString() + " ");

--- a/src/test/java/seedu/momentum/testutil/SortCommandUtil.java
+++ b/src/test/java/seedu/momentum/testutil/SortCommandUtil.java
@@ -6,29 +6,29 @@ import seedu.momentum.model.project.SortType;
 public class SortCommandUtil {
 
     public static final SortCommand DEFAULT_SORT_COMMAND =
-            new SortCommand(SortType.NULL, true, true);
+            new SortCommand(SortType.NULL, true, true, true);
 
-    public static final SortCommand ALPHA_ASCENDING_COMMAND =
-            new SortCommand(SortType.ALPHA, true, false);
+    public static final SortCommand ALPHA_ASCENDING_COMMAND_WITH_COMPLETION_STATUS =
+            new SortCommand(SortType.ALPHA, true, false, true);
 
     public static final SortCommand ALPHA_DESCENDING_COMMAND =
-            new SortCommand(SortType.ALPHA, false, false);
+            new SortCommand(SortType.ALPHA, false, false, false);
 
-    public static final SortCommand DEADLINE_ASCENDING_COMMAND =
-            new SortCommand(SortType.DEADLINE, true, false);
+    public static final SortCommand DEADLINE_ASCENDING_COMMAND_WITH_COMPLETION_STATUS =
+            new SortCommand(SortType.DEADLINE, true, false, true);
 
     public static final SortCommand DEADLINE_DESCENDING_COMMAND =
-            new SortCommand(SortType.DEADLINE, false, false);
+            new SortCommand(SortType.DEADLINE, false, false, false);
 
     public static final SortCommand CREATED_DATE_ASCENDING_COMMAND =
-            new SortCommand(SortType.CREATED, true, false);
+            new SortCommand(SortType.CREATED, true, false, false);
 
-    public static final SortCommand CREATED_DATE_DESCENDING_COMMAND =
-            new SortCommand(SortType.CREATED, false, false);
+    public static final SortCommand CREATED_DATE_DESCENDING_COMMAND_WITH_COMPLETION_STATUS =
+            new SortCommand(SortType.CREATED, false, false, true);
 
     public static final SortCommand NULL_SORT_TYPE_ASCENDING_NON_DEFAULT_COMMAND =
-            new SortCommand(SortType.NULL, true, false);
+            new SortCommand(SortType.NULL, true, false, true);
 
     public static final SortCommand NULL_SORT_TYPE_DESCENDING_NON_DEFAULT_COMMAND =
-            new SortCommand(SortType.NULL, false, false);
+            new SortCommand(SortType.NULL, false, false, true);
 }

--- a/src/test/java/seedu/momentum/testutil/TypicalProjects.java
+++ b/src/test/java/seedu/momentum/testutil/TypicalProjects.java
@@ -1,5 +1,6 @@
 package seedu.momentum.testutil;
 
+import static seedu.momentum.logic.commands.CommandTestUtil.VALID_COMPLETION_STATUS_BOB;
 import static seedu.momentum.logic.commands.CommandTestUtil.VALID_CREATED_DATE_AMY;
 import static seedu.momentum.logic.commands.CommandTestUtil.VALID_CREATED_DATE_BOB;
 import static seedu.momentum.logic.commands.CommandTestUtil.VALID_DEADLINE_DATE_AMY;
@@ -17,13 +18,13 @@ import java.util.Arrays;
 import java.util.List;
 
 import seedu.momentum.model.ProjectBook;
+import seedu.momentum.model.project.CompletionStatus;
 import seedu.momentum.model.project.Project;
 
 /**
  * A utility class containing a list of {@code Project} objects to be used in tests.
  */
 public class TypicalProjects {
-
     public static final Project ALICE = new ProjectBuilder().withName("Alice Pauline")
             .withDescription("Likes coding")
             .withCreatedDate("2000-11-05")
@@ -32,12 +33,14 @@ public class TypicalProjects {
     public static final Project BENSON = new ProjectBuilder().withName("Benson Meier")
             .withDescription("Likes dogs")
             .withCreatedDate("2000-11-05")
+            .withCompletionStatus(CompletionStatus.COMPLETED)
             .withDeadline("2020-11-05", "12:43:12", "2000-11-05")
             .withTags("owesMoney", "friends")
             .withDurations(TypicalWorkDuration.DURATION_ONE_DAY)
             .withTimer(TypicalTimers.DAY).build();
     public static final Project CARL = new ProjectBuilder().withName("Carl Kurz")
             .withDescription("Likes poodles")
+            .withCompletionStatus(CompletionStatus.COMPLETED)
             .withCreatedDate("2019-08-02")
             .withEmptyDeadline()
             .build();
@@ -57,6 +60,7 @@ public class TypicalProjects {
             .withDeadline("2020-03-21", "05:02:09", "2019-03-21").build();
     public static final Project GEORGE = new ProjectBuilder().withName("George Best")
             .withDescription("Likes you")
+            .withCompletionStatus(CompletionStatus.COMPLETED)
             .withCreatedDate("2019-07-28")
             .withEmptyDeadline()
             .build();
@@ -75,6 +79,7 @@ public class TypicalProjects {
             .withTags(VALID_TAG_FRIEND).build();
     public static final Project BOB = new ProjectBuilder().withName(VALID_NAME_BOB)
             .withDescription(VALID_DESCRIPTION_BOB)
+            .withCompletionStatus(VALID_COMPLETION_STATUS_BOB)
             .withCreatedDate(VALID_CREATED_DATE_BOB)
             .withDeadline(VALID_DEADLINE_DATE_BOB, VALID_CREATED_DATE_BOB)
             .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();


### PR DESCRIPTION
Add a completionstatus class in project
Add a completionstatuspredicate for find
Add a completionstatuscompare for sort

completion status is incomplete by default 

for edit and add, c/ will reverse the status
add n/a c/ -> project a that is completed
edit 1 c/ -> project 1 will become incomplete if completed

Find will find all projects by default. 
"c/ completed" will only search for completed projects only
"c/ incomplete" will only search for incomplete projects only

Sort will sort the projects into incomplete then complete by default 
sort c/ will disable this

The sorting is not maintained in the default order automatically after editing any field like name or completion status (but is maintained after an add command). Should we implement this? 